### PR TITLE
fix: 7 quick-win fixes (macOS, detection, templates, docs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to superflow will be documented in this file.
 
+## [2.0.1] - 2026-03-21
+
+### Fixed
+- **README version** now matches CHANGELOG (v2.0.0)
+- **macOS timeout**: document `perl -e 'alarm N; exec @ARGV'` as default macOS fallback — `timeout` and `gtimeout` are not available out of the box
+- **Secondary provider detection**: replaced `which` check with smoke test — a binary can exist but fail without API keys
+- **Removed `mode: bypassPermissions`** from agent dispatch rules — not a valid Agent tool parameter
+- **Heredoc templates in prompts**: fixed `<<'PROMPT'` (quoted, prevents `$()` expansion) → `<<PROMPT` (unquoted) in code-quality-reviewer and product-reviewer
+- **Superpowers skill reference**: `superpowers:debugging` → `superpowers:systematic-debugging`
+- **Spec/plan directories**: added `mkdir -p` instructions before writing to `docs/superpowers/specs/` and `docs/superpowers/plans/`
+
 ## [2.0.0] - 2026-03-21
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # superflow
 
-**v1.2.0** · A Claude Code skill for autonomous product-to-production development.
+**v2.0.0** · A Claude Code skill for autonomous product-to-production development.
 
 Combines collaborative product discovery with fully autonomous execution — you discuss what to build, then the agent builds it end-to-end without stopping.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -226,7 +226,7 @@ Present design section by section. Scale depth to complexity.
 
 ### Step 6: Spec Document
 
-Write spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
+Create the directory if needed (`mkdir -p docs/superpowers/specs`) and write spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
 
 ### Step 7: Spec Review (cross-model or split-focus)
 
@@ -241,7 +241,7 @@ Fix issues from both review agents. Re-review if NEEDS_REVISION.
 
 ### Step 8: Implementation Plan
 
-Write plan to `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`.
+Create the directory if needed (`mkdir -p docs/superpowers/plans`) and write plan to `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`.
 
 **Plan structure:**
 - Break into sprints (logical chunks, each deployable independently)
@@ -340,7 +340,6 @@ git worktree remove .worktrees/sprint-N
 
 **Implementation agents:**
 - Use `run_in_background: true` for independent tasks
-- Use `mode: bypassPermissions` for all implementation agents
 - Use `model: sonnet` for mechanical tasks (1-2 files, clear spec)
 - Use default model for complex integration tasks
 - Maximum concurrent agents: limited only by task independence
@@ -485,31 +484,38 @@ When no secondary provider is available, dispatch two Claude agents with **diffe
 
 ### Secondary Provider Detection
 
-At the very beginning of the session, detect available secondary providers:
+At the very beginning of the session, detect available secondary providers with a smoke test:
 
 ```bash
-# Check for known CLI-based LLM providers
-which codex 2>/dev/null && codex --version 2>/dev/null
-which gemini 2>/dev/null && gemini --version 2>/dev/null
-which aider 2>/dev/null && aider --version 2>/dev/null
+# Check for known CLI-based LLM providers (smoke test — not just `which`)
+# A provider is "available" only if it can produce a response
+codex exec --full-auto "say ok" 2>/dev/null && echo "CODEX_OK"
+gemini -p "say ok" 2>/dev/null && echo "GEMINI_OK"
+aider --message "say ok" --yes 2>/dev/null && echo "AIDER_OK"
 ```
 
-Use the first available provider. If none found — use Tier 2 (split-focus) silently. Never fail or warn the user about missing providers.
+**Important:** `which <provider>` is NOT sufficient — a binary can exist but fail due to missing API keys or auth. Always run a smoke test that requires a real API response.
+
+Use the first provider that passes the smoke test. If none found — use Tier 2 (split-focus) silently. Never fail or warn the user about missing providers.
 
 ### Secondary Provider Invocation
 
-All secondary providers are invoked via Bash tool with a timeout:
+All secondary providers are invoked via Bash tool with a timeout.
+
+**Timeout command (platform-aware):**
+- Linux: `timeout 300 <cmd>`
+- macOS with coreutils: `gtimeout 300 <cmd>`
+- macOS without coreutils (default): `perl -e 'alarm 300; exec @ARGV' <cmd>`
 
 ```bash
-# Pattern: timeout + provider CLI + non-interactive mode + prompt
-# macOS: use gtimeout (brew install coreutils) or timeout
-# Linux: use timeout
-
-# Codex example:
-timeout 300 codex exec --full-auto "REVIEW_PROMPT" 2>&1
+# Codex example (macOS without coreutils):
+perl -e 'alarm 300; exec @ARGV' codex exec --full-auto "REVIEW_PROMPT" 2>&1
 
 # Gemini example:
-timeout 300 gemini -p "REVIEW_PROMPT" 2>&1
+perl -e 'alarm 300; exec @ARGV' gemini -p "REVIEW_PROMPT" 2>&1
+
+# Linux:
+timeout 300 codex exec --full-auto "REVIEW_PROMPT" 2>&1
 ```
 
 Key rules:
@@ -517,6 +523,7 @@ Key rules:
 - Include ALL context (file paths, project conventions, constraints)
 - Always `git diff` after secondary provider implementations to verify scope
 - 5-minute timeout to prevent hangs
+- Use Bash `timeout` parameter (up to 600000ms) as an alternative to shell-level timeouts
 
 ---
 
@@ -555,7 +562,7 @@ SuperFlow uses these superpowers skills internally:
 - `superpowers:test-driven-development` — TDD within tasks (see `prompts/implementer.md`)
 - `superpowers:verification-before-completion` — Rule 6, evidence-based completion
 - `superpowers:using-git-worktrees` — sprint isolation via worktrees
-- `superpowers:debugging` — systematic debugging protocol
+- `superpowers:systematic-debugging` — systematic debugging protocol
 
 SuperFlow OVERRIDES these superpowers behaviors:
 - Brainstorming: adds proactive product suggestions (not just questions)

--- a/prompts/code-quality-reviewer.md
+++ b/prompts/code-quality-reviewer.md
@@ -64,8 +64,12 @@ Every finding must have:
 When a secondary provider is available, dispatch it in parallel with the Claude agent. Both get the full base prompt above — the value comes from model diversity, not prompt diversity.
 
 **Secondary provider invocation:**
+
+Build the prompt string first, then pass it to the provider. The heredoc must use an **unquoted** delimiter so `$()` expansions work:
+
 ```bash
-timeout 300 <provider> <non-interactive-flag> "$(cat <<'PROMPT'
+# Build prompt with expanded variables
+REVIEW_PROMPT="$(cat <<PROMPT
 You are reviewing code changes for quality.
 
 ## Diff
@@ -88,7 +92,10 @@ Be specific — file:line references. Only flag issues that would cause real pro
 ### Minor
 ### Verdict: APPROVE | REQUEST_CHANGES
 PROMPT
-)" 2>&1
+)"
+
+# Pass to provider (use platform-appropriate timeout)
+perl -e 'alarm 300; exec @ARGV' <provider> <non-interactive-flag> "$REVIEW_PROMPT" 2>&1
 ```
 
 ## Split-Focus Fallback (Tier 2)

--- a/prompts/product-reviewer.md
+++ b/prompts/product-reviewer.md
@@ -72,8 +72,12 @@ Every finding must include a concrete scenario:
 When a secondary provider is available, dispatch it in parallel with the Claude agent. Both get the full base prompt above.
 
 **Secondary provider invocation:**
+
+Build the prompt string first, then pass it to the provider. The heredoc must use an **unquoted** delimiter so `$()` expansions work:
+
 ```bash
-timeout 300 <provider> <non-interactive-flag> "$(cat <<'PROMPT'
+# Build prompt with expanded variables
+REVIEW_PROMPT="$(cat <<PROMPT
 You are a Product Owner reviewing delivered software against its specification.
 
 ## Spec
@@ -93,7 +97,10 @@ $(git log SPRINT_BASE..HEAD --oneline)
 ### UX Concerns
 ### Verdict: ACCEPTED | NEEDS_FIXES
 PROMPT
-)" 2>&1
+)"
+
+# Pass to provider (use platform-appropriate timeout)
+perl -e 'alarm 300; exec @ARGV' <provider> <non-interactive-flag> "$REVIEW_PROMPT" 2>&1
 ```
 
 ## Split-Focus Fallback (Tier 2)


### PR DESCRIPTION
## Summary

Seven targeted fixes discovered while using superflow in practice on macOS. All are quick wins — no architectural changes, no behavior changes.

### Fixes

1. **README version mismatch** — header said v1.2.0 while CHANGELOG had v2.0.0
2. **macOS timeout command** — neither `timeout` nor `gtimeout` are available on macOS by default. Documented `perl -e 'alarm N; exec @ARGV'` as universal fallback
3. **Provider detection needs smoke test** — `which gemini` returns success even without an API key configured, so the skill thinks a provider is available when it isn't. Replaced with actual invocation test
4. **`mode: bypassPermissions` doesn't exist** — referenced in Agent Dispatch Rules but it's not a valid parameter for the Agent tool (valid: `description`, `prompt`, `model`, `run_in_background`, `isolation`, `subagent_type`)
5. **Heredoc templates prevent `$()` expansion** — `<<'PROMPT'` (quoted delimiter) in code-quality-reviewer and product-reviewer templates suppresses command substitution, so `$(git diff ...)` goes through as literal text instead of the actual diff. Fixed to `<<PROMPT` (unquoted)
6. **Wrong superpowers skill name** — `superpowers:debugging` → `superpowers:systematic-debugging`
7. **Missing `mkdir -p` for spec/plan directories** — skill instructs writing to `docs/superpowers/specs/` and `docs/superpowers/plans/` without ensuring the directories exist

### How discovered

All issues found while testing superflow on a real project (MCP server) on macOS. Issues 2, 3, and 5 caused actual failures during a session; the rest were caught during code review.

### Dependencies

- This PR is based on `refactor/remove-codex-dependency` (PR #1) — merge that first
- Fixes 1 and 5 only exist in the refactored code

### Files changed

- `SKILL.md` — fixes 2, 3, 4, 6, 7
- `README.md` — fix 1
- `prompts/code-quality-reviewer.md` — fix 5
- `prompts/product-reviewer.md` — fix 5
- `CHANGELOG.md` — v2.0.1 entry