### PR TITLE
refactor: provider-agnostic dual-model reviews (Codex preferred, with fallbacks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Most AI coding workflows are either too hands-on (you babysit every step) or too
 
 **Phase 1 — You talk, agent listens and proposes.** Freeflow product conversation with research, expert lenses, and proactive suggestions. The agent doesn't just ask questions — it proposes ideas, challenges assumptions, and brings best practices from the domain. This phase takes time, and that's intentional.
 
-**Phase 2 — You say "go", agent executes autonomously.** Zero interaction until done. The agent creates a PR per sprint using git worktrees for isolation, uses parallel subagents for implementation, runs dual-provider reviews (Claude + Codex), enforces test-first development, requires verification evidence before any completion claim, and does product acceptance testing. You get a report with ready-to-merge PRs at the end.
+**Phase 2 — You say "go", agent executes autonomously.** Zero interaction until done. The agent creates a PR per sprint using git worktrees for isolation, uses parallel subagents for implementation, runs dual-model reviews (Codex preferred, with fallbacks), enforces test-first development, requires verification evidence before any completion claim, and does product acceptance testing. You get a report with ready-to-merge PRs at the end.
 
 ## What a Session Looks Like
 
@@ -31,7 +31,7 @@ Agent: [silently reads codebase, launches research agents]
 Agent: [asks about your vision, proposes ideas from competitor analysis]
 Agent: [presents 2-3 approaches, recommends one]
 Agent: [presents design section by section]
-Agent: [writes spec, reviews with Claude + Codex in parallel, fixes issues]
+Agent: [writes spec, reviews with dual-model reviewers in parallel, fixes issues]
 Agent: [writes implementation plan with bite-sized steps, reviews, fixes]
 Agent: "Plan ready — 4 sprints, 28 steps, ~4 PRs. Go?"
 
@@ -60,9 +60,9 @@ Agent: "Done. 4 PRs ready:
 | 4 | Approaches + recommendation | **Yes — choice** |
 | 5 | Design presentation | **Yes — discussion** |
 | 6 | Write spec document | No |
-| 7 | Spec review (Claude + Codex parallel) | No |
+| 7 | Spec review (dual-model parallel) | No |
 | 8 | Write implementation plan (bite-sized steps) | No |
-| 9 | Plan review (Claude + Codex parallel) | No |
+| 9 | Plan review (dual-model parallel) | No |
 | 10 | Your approval to start | **Yes — "go"** |
 
 4 interactive steps, 6 autonomous. Your involvement is one continuous conversation (steps 3-5) plus one "go" (step 10).
@@ -86,9 +86,9 @@ For each Sprint:
 +-- Run baseline tests (verify clean starting state)
 +-- Implement tasks (maximum parallel agents, TDD cycle)
 |   +-- Per task: write failing test -> verify fail -> implement -> verify pass
-|   +-- Spec review -> code quality review (Claude + Codex)
+|   +-- Spec review -> code quality review (dual-model)
 |   +-- Verify: run tests, paste output as evidence
-+-- Product Acceptance Review (Claude + Codex parallel)
++-- Product Acceptance Review (dual-model parallel)
 |   +-- Verify implementation matches spec intent
 +-- Run full test suite, push, create PR
 +-- Clean up worktree
@@ -102,7 +102,7 @@ For each Sprint:
 - **Test-first development** — write failing test, verify failure, implement, verify pass. Never skip steps
 - **Verification discipline** — no completion claims without actual test output as evidence
 - **Max parallelism** — 5 agents if 5 tasks are independent. Never serialize independent work
-- **Dual-provider reviews** — Claude + Codex review in parallel. Different models catch different bugs
+- **Dual-model reviews** — Claude + secondary provider (Codex preferred) in parallel; split-focus Claude fallback when no provider available
 - **Product acceptance** — after code review passes, product agents verify the implementation matches the *intent* of the spec
 - **Systematic debugging** — when tests fail, investigate root cause before attempting fixes
 - **Never stops** — accumulates issues and reports at the end. Never asks "should I continue?"
@@ -110,7 +110,7 @@ For each Sprint:
 ## 6 Rules
 
 1. **NEVER pause** during autonomous execution
-2. **ALWAYS use Codex** for reviews (parallel with Claude)
+2. **ALWAYS use dual-model reviews** — Codex preferred, other providers as fallback, split-focus Claude as last resort
 3. **PR per sprint** — smaller PRs, easier to review
 4. **Maximum parallelism** — use all available agents
 5. **Proactive product thinking** — propose ideas, don't just ask questions
@@ -123,11 +123,11 @@ superflow uses the user's default model for planning and review (where critical 
 | Phase | Task | Model | Reasoning |
 |-------|------|-------|-----------|
 | Phase 1 | Brainstorming, spec, plan | Opus (recommended) | ultrathink for deep reasoning |
-| Phase 1 | Codex product ideas | Codex default | Parallel brainstorming partner |
+| Phase 1 | Independent product expert | Secondary provider (Codex preferred) | Parallel brainstorming partner |
 | Phase 2 | Implementation agents | Sonnet | Standard — plan is detailed enough |
 | Phase 2 | Code quality review | Opus (recommended) | ultrathink for critical analysis |
 | Phase 2 | Product acceptance | Opus (recommended) | ultrathink for intent verification |
-| Phase 2 | Codex reviews | Codex default | xhigh reasoning by default |
+| Phase 2 | Secondary provider reviews | Codex default (or other) | Cross-model diversity |
 
 **Reasoning depth:** superflow uses `ultrathink` in prompts for spec review, plan review, and product acceptance — triggering extended thinking regardless of user's default reasoning effort setting. Implementation agents use standard reasoning since the plan is already detailed.
 
@@ -145,7 +145,7 @@ claude --dangerously-skip-permissions
 
 **Reasoning effort:** Set to `high` or `max` via `/effort` in Claude Code. superflow adds `ultrathink` to critical prompts on top of this.
 
-**Codex:** Runs with `--full-auto` by default (sandboxed to workspace).
+**Secondary providers:** Codex runs with `--full-auto` by default. Other providers use their non-interactive mode.
 
 ## Safety Warning
 
@@ -156,7 +156,7 @@ superflow runs in fully autonomous mode during Phase 2 — it creates branches, 
 - **Disposable branch** — always works on feature branches, never commits to main directly
 - **Review before merge** — PRs are created but never auto-merged; you review and merge manually
 
-`--dangerously-skip-permissions` disables all safety prompts. `--full-auto` gives Codex write access to your workspace. Only use these in environments you're comfortable with.
+`--dangerously-skip-permissions` disables all safety prompts. `--full-auto` gives Codex write access to your workspace. Only use in environments you're comfortable with.
 
 ## Install
 
@@ -174,9 +174,9 @@ cp superflow/prompts/*.md ~/.claude/skills/superflow/prompts/
 ## Requirements
 
 - **Claude Code CLI** — the host environment
-- **Codex CLI** (optional but recommended) — `npm install -g @openai/codex` + `OPENAI_API_KEY` env var. Enables dual-provider reviews. Without Codex, superflow falls back to two Claude agents with split review focus (technical vs product) instead of skipping reviews
+- **Secondary provider CLI** (optional, recommended) — Codex preferred (`npm install -g @openai/codex` + `OPENAI_API_KEY`), but any CLI-based LLM works (Gemini CLI, Aider, etc.). Enables dual-model reviews. Without one, superflow falls back to two Claude agents with split review focus
 - **GitHub CLI** (`gh`) — for PR creation
-- **macOS users**: `brew install coreutils` provides `gtimeout` for Codex timeout management. If coreutils is unavailable, superflow falls back to a Perl-based timeout (`perl -e 'alarm N; exec @ARGV'`) which works on any system with Perl (including stock macOS)
+- **macOS users**: `brew install coreutils` provides `gtimeout` for timeout management. If unavailable, superflow falls back to Perl-based timeout (`perl -e 'alarm N; exec @ARGV'`)
 
 ## Files
 
@@ -185,8 +185,8 @@ cp superflow/prompts/*.md ~/.claude/skills/superflow/prompts/
 | `SKILL.md` | Main skill definition — orchestrator loaded by Claude Code |
 | `prompts/implementer.md` | Implementation agent template with TDD enforcement |
 | `prompts/spec-reviewer.md` | Spec compliance reviewer with calibration rules |
-| `prompts/code-quality-reviewer.md` | Code quality reviewer with anti-noise rules + Codex template |
-| `prompts/product-reviewer.md` | Product acceptance reviewer + Codex template |
+| `prompts/code-quality-reviewer.md` | Code quality reviewer with anti-noise rules + secondary provider/split-focus templates |
+| `prompts/product-reviewer.md` | Product acceptance reviewer + secondary provider/split-focus templates |
 | `prompts/testing-guidelines.md` | Testing anti-patterns and best practices reference |
 
 ## Relationship with Superpowers
@@ -206,7 +206,7 @@ superflow is built on top of [Superpowers](https://github.com/obra/superpowers) 
 ### What superflow adds
 - **Two-phase architecture** — collaborative discovery, then fully autonomous execution
 - **Context drift prevention** — checkpoint re-reads, self-check questions, sprint checklists
-- **Dual-model reviews** — Claude + Codex in parallel ("two models catch more bugs than one")
+- **Dual-model reviews** — Claude + secondary provider in parallel, split-focus fallback ("two reviewers catch more bugs than one")
 - **Product Acceptance Review** — 3rd review stage verifying spec *intent*, not just code quality
 - **PR per sprint** — smaller, reviewable, independently deployable PRs
 - **Best practices research** — parallel research agents before brainstorming
@@ -227,7 +227,7 @@ Built during a real session: analytics engine for a family finance tracker. 16 t
 |------|--------------|
 | Never pause | User had to ask 3 times to stop confirming |
 | PR per sprint | 20-commit PR was too big to review |
-| Always use Codex | Rule existed but wasn't enforced — Codex was never invoked |
+| Always use dual-model reviews | Rule existed but wasn't enforced — second reviewer was never invoked |
 | Proactive thinking | Brainstorming was one-sided — only questions, no proposals |
 | Product acceptance | Code passed technical review but missed product intent |
 | Verification evidence | Agent claimed "tests pass" without running them |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: superflow
-description: "Use when user says 'superflow', 'суперфлоу', or asks for full dev workflow. Two phases: (1) collaborative Product Discovery with multi-expert brainstorming, (2) fully autonomous execution with PR-per-sprint, git worktrees, Codex reviews, max parallelism, and verification discipline."
+description: "Use when user says 'superflow', 'суперфлоу', or asks for full dev workflow. Two phases: (1) collaborative Product Discovery with multi-expert brainstorming, (2) fully autonomous execution with PR-per-sprint, git worktrees, dual-model reviews, max parallelism, and verification discipline."
 ---
 
 # Superflow — Product-to-Production Workflow
@@ -36,7 +36,7 @@ isolated context windows — preventing overflow and ensuring each sprint gets f
 At session start, before anything else:
 
 1. Read `.claude/rules/superflow-enforcement.md`
-2. Detect Codex: `codex --version 2>/dev/null` (binary can exist without API keys — test actual invocation)
+2. Detect secondary providers (see [Secondary Provider Detection](#secondary-provider-detection))
 3. Detect timeout command (see [Timeout Helper](#timeout-helper))
 4. Detect Telegram: check if `mcp__plugin_telegram_telegram__reply` is available
 5. Detect mode: existing code = Enhancement, empty repo = Greenfield
@@ -52,7 +52,7 @@ At session start, before anything else:
 2. **Use git worktrees for sprint isolation** — `git worktree add .worktrees/sprint-N`.
    Worktrees prevent file conflicts and enable clean rollback.
 
-3. **Run Product Acceptance Review before every PR** — dispatch Claude + Codex reviewers.
+3. **Run Product Acceptance Review before every PR** — dispatch Claude + secondary provider reviewers.
    Code can be technically clean but productively wrong; this catches intent mismatches.
 
 4. **Run tests and paste output before claiming done.** "Should work" is not evidence.
@@ -60,7 +60,8 @@ At session start, before anything else:
 5. **Re-read reference files at each phase transition** — use the Read tool on the relevant
    file. After compaction, the skill content is gone; re-reading restores it.
 
-6. **Use Codex for reviews** when available. Two different models catch different bugs.
+6. **Use dual-model reviews** — Codex preferred, other providers as fallback, split-focus Claude
+   as last resort. Two different models catch different bugs.
 
 7. **One PR per sprint.** Smaller PRs are easier to review and safer to deploy.
 
@@ -79,7 +80,7 @@ Before proceeding to the next phase or sprint, verify:
 - Did I create a git worktree for this sprint? → Create one if not.
 - Did I run tests and see passing output? → Run them if not.
 - Did I run Product Acceptance Review? → Launch it if not.
-- Did I use Codex for reviews? → Use it if available.
+- Did I use dual-model review? → Codex if available, other provider, or split-focus fallback.
 
 ---
 
@@ -91,13 +92,13 @@ Summary:
 
 1. **Context Exploration** — read CLAUDE.md, git history, understand architecture
 2. **Research** — dispatch background agents for best practices, libraries, competitors
-3. **Codex Ideas** — dispatch Codex as product expert (parallel with brainstorming)
+3. **Independent Product Expert** — dispatch secondary provider as product expert (parallel with brainstorming)
 4. **Brainstorming** — freeflow with product focus, questions → proposals → questions
 5. **Product Summary** — present features, problems solved, scope → **user approves**
 6. **Spec Document** — `mkdir -p docs/superpowers/specs` then write to `docs/superpowers/specs/`
-7. **Spec Review** — Claude + Codex in parallel
+7. **Spec Review** — Claude + secondary provider in parallel
 8. **Implementation Plan** — `mkdir -p docs/superpowers/plans` then write to `docs/superpowers/plans/`
-9. **Plan Review** — Claude + Codex in parallel
+9. **Plan Review** — Claude + secondary provider in parallel
 10. **User Approval** — last interaction before autonomous execution
 
 Step 5 (Product Summary) is the gate — proceed to spec only after user confirms.
@@ -123,7 +124,7 @@ Sprint N:
   1. Re-read references/phase2-execution.md
   2. Create worktree: git worktree add .worktrees/sprint-N
   3. Dispatch implementation subagents (Agent tool, mode: bypassPermissions)
-  4. Run tests → Product Acceptance Review (Claude + Codex)
+  4. Run tests → Product Acceptance Review (Claude + secondary provider)
   5. Create PR targeting main
   6. Clean up worktree
   7. Send Telegram progress (if connected)
@@ -136,29 +137,44 @@ Sprint N:
 [ ] Tests pass with evidence (actual output pasted)
 [ ] Lint clean
 [ ] TypeCheck clean
-[ ] Product Acceptance Review launched (Claude + Codex)
+[ ] Product Acceptance Review launched (Claude + secondary provider or split-focus)
 [ ] Product Acceptance approved
 [ ] Only then → create PR
 ```
 
 ---
 
-## Codex Integration
+## Secondary Provider Integration
 
-Detect at startup: `codex --version 2>/dev/null` (not just `which codex` — binary can exist without API keys).
+Dual-model reviews use two different AI models for independent review. Codex is the preferred
+secondary provider, but any CLI-based LLM works.
 
-Use for: spec review, plan review, code quality review (complex tasks).
+**Fallback chain** (use the first available):
+1. **Codex** (preferred) — `$TIMEOUT_CMD 600 codex exec --full-auto "PROMPT" 2>&1`
+2. **Other CLI provider** (Gemini CLI, Aider, etc.) — `$TIMEOUT_CMD 600 <provider> <flags> "PROMPT" 2>&1`
+3. **Split-focus Claude** (last resort) — two Claude agents with different review lenses
 
-**When Codex is unavailable**, do NOT skip reviews. Instead, dispatch **two Claude agents** with split focus:
+**When NO secondary provider is available**, do NOT skip reviews. Dispatch **two Claude agents**
+with split focus:
 - **Agent A (Technical):** security, architecture, performance, correctness
 - **Agent B (Product):** spec compliance, UX gaps, edge cases, data integrity
 
 Two agents with different prompts catch more than one generalist reviewer.
 
+### Secondary Provider Detection
+
+Detect at startup with a smoke test (not just `which` — binary can exist without API keys):
+
 ```bash
-# Use the timeout helper (see below):
-$TIMEOUT_CMD 600 codex exec --full-auto "PROMPT" 2>&1
+# Preferred: Codex
+codex --version 2>/dev/null && SECONDARY_PROVIDER="codex"
+# Fallback: other providers
+[ -z "$SECONDARY_PROVIDER" ] && gemini --version 2>/dev/null && SECONDARY_PROVIDER="gemini"
+[ -z "$SECONDARY_PROVIDER" ] && aider --version 2>/dev/null && SECONDARY_PROVIDER="aider"
+# If none found → split-focus Claude (no SECONDARY_PROVIDER set)
 ```
+
+Use the detected provider silently. Never warn about missing providers.
 
 ---
 
@@ -201,7 +217,7 @@ If you catch yourself thinking any of these, course-correct:
 | "I'll just write the code directly" | Dispatch a subagent — it gets a clean context window |
 | "Too simple for a worktree" | Create the worktree — it takes 5 seconds |
 | "Skip review, it's trivial" | Run the review — trivial changes break production |
-| "Codex isn't needed here" | Use it if available — different models catch different bugs |
+| "Second reviewer isn't needed" | Two reviewers catch more bugs. Use Codex, other provider, or split-focus |
 | "Let me ask the user" | After plan approval, execute silently |
 | "Tests are green so it works" | Verify behavior, not just test output |
 | "One big PR is fine" | Split into one PR per sprint |

--- a/prompts/code-quality-reviewer.md
+++ b/prompts/code-quality-reviewer.md
@@ -59,13 +59,14 @@ Every finding must have:
 ### Verdict: APPROVE | REQUEST_CHANGES
 ```
 
-## Codex Parallel Review
+## Secondary Provider Review
 
-When dispatching to Codex in parallel, use this invocation:
+When dispatching a secondary provider in parallel with the Claude agent, both get the full
+review prompt. The value comes from model diversity, not prompt diversity.
 
+**Codex (preferred):**
 ```bash
-codex --approval-mode full-auto --quiet \
-  -p "$(cat <<PROMPT
+REVIEW_PROMPT="$(cat <<PROMPT
 You are reviewing code changes for quality.
 
 ## Diff
@@ -88,5 +89,19 @@ Be specific — file:line references. Only flag issues that would cause real pro
 ### Minor
 ### Verdict: APPROVE | REQUEST_CHANGES
 PROMPT
-)" 2>&1
+)"
+
+$TIMEOUT_CMD 600 codex exec --full-auto "$REVIEW_PROMPT" 2>&1
 ```
+
+**Other providers:** Replace `codex exec --full-auto` with the provider's non-interactive flag.
+
+## Split-Focus Fallback
+
+When no secondary provider is available, dispatch two Claude agents with different focus:
+
+**Agent A — Correctness focus:**
+Add to the base prompt: "Focus your review on: correctness (logic errors, off-by-one, null/undefined), edge cases (what inputs break this?), error handling (are errors caught and helpful?), and security (injection, auth, data exposure)."
+
+**Agent B — Architecture focus:**
+Add to the base prompt: "Focus your review on: performance (O(n^2), N+1 queries, memory leaks), pattern compliance (does this follow project conventions?), test quality (do tests verify behavior or mock behavior?), and maintainability (will this be clear in 6 months?)."

--- a/prompts/product-reviewer.md
+++ b/prompts/product-reviewer.md
@@ -67,13 +67,14 @@ Every finding must include a concrete scenario:
 ### Verdict: ACCEPTED | NEEDS_FIXES
 ```
 
-## Codex Parallel Review
+## Secondary Provider Review
 
-When dispatching to Codex in parallel:
+When dispatching a secondary provider in parallel with the Claude agent, both get the full
+review prompt.
 
+**Codex (preferred):**
 ```bash
-codex --approval-mode full-auto --quiet \
-  -p "$(cat <<PROMPT
+REVIEW_PROMPT="$(cat <<PROMPT
 You are a Product Owner reviewing delivered software against its specification.
 
 ## Spec
@@ -93,8 +94,22 @@ $(git log SPRINT_BASE..HEAD --oneline)
 ### UX Concerns
 ### Verdict: ACCEPTED | NEEDS_FIXES
 PROMPT
-)" 2>&1
+)"
+
+$TIMEOUT_CMD 600 codex exec --full-auto "$REVIEW_PROMPT" 2>&1
 ```
+
+**Other providers:** Replace `codex exec --full-auto` with the provider's non-interactive flag.
+
+## Split-Focus Fallback
+
+When no secondary provider is available, dispatch two Claude agents with different focus:
+
+**Agent A — Spec fit focus:**
+Add to the base prompt: "Focus on spec-to-implementation fit and data correctness. Does the code deliver what the spec described? Any requirements skipped or misinterpreted? Are amounts, dates, currencies handled correctly?"
+
+**Agent B — User scenarios focus:**
+Add to the base prompt: "Focus on user scenarios and edge cases. Walk through the happy path end-to-end. What happens on empty input, missing data, first-time use? Are error messages helpful? Can the user complete the full task without getting stuck?"
 
 ## When Product Review Finds Issues
 

--- a/references/phase1-discovery.md
+++ b/references/phase1-discovery.md
@@ -23,15 +23,19 @@ Before brainstorming, launch parallel research agents to gather external context
 
 **This is NOT optional.** 5 minutes of research prevents hours of reinventing.
 
-## Step 2.5: Codex as Product Expert (parallel with brainstorming)
+## Step 2.5: Independent Product Expert (parallel with brainstorming)
 
-If Codex is available, dispatch it to generate product ideas independently:
+Dispatch an independent product expert to generate ideas in parallel.
 
+**If secondary provider is available** (Codex preferred):
 ```bash
 $TIMEOUT_CMD 600 codex exec --full-auto "You are a Product Expert. Given this context about [project] and [research], propose 3-5 concrete product improvements. For each: what, why it matters, how it could work." 2>&1
 ```
 
-Run IN PARALLEL with brainstorming. Two models produce different ideas.
+**If no secondary provider** — dispatch a background Claude Agent with the same prompt.
+An independent agent produces different ideas because it has no conversational anchoring bias.
+
+Run IN PARALLEL with brainstorming. Two models (or two independent agents) produce different ideas.
 
 ## Step 3: Multi-Expert Brainstorming
 
@@ -105,9 +109,11 @@ mkdir -p docs/superpowers/specs
 
 Write spec to `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`.
 
-## Step 7: Spec Review (Claude + Codex PARALLEL)
+## Step 7: Spec Review (dual-model PARALLEL)
 
-Launch BOTH in parallel. Use `prompts/spec-reviewer.md`.
+Launch Claude + secondary provider in parallel. Use `prompts/spec-reviewer.md`.
+If no secondary provider, use split-focus: two Claude agents — one checks completeness/consistency,
+the other checks scope/YAGNI.
 Fix issues. Re-review if NEEDS_REVISION.
 
 ## Step 8: Implementation Plan
@@ -124,9 +130,9 @@ Write plan to `docs/superpowers/plans/YYYY-MM-DD-<topic>.md`.
 - Each step = 2-5 minutes of work (atomic operations)
 - Each task has: files, steps, commit message
 
-## Step 9: Plan Review (Claude + Codex PARALLEL)
+## Step 9: Plan Review (dual-model PARALLEL)
 
-Same as spec review. Both must APPROVE.
+Same as spec review. Both reviewers must APPROVE.
 
 ## Step 10: User Approval
 

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -57,18 +57,21 @@ For each Sprint N:
 |          4. Architecture: patterns, coupling, performance
 |          Return ACCEPTED or NEEDS_FIXES.", run_in_background=true)
 |
-|      ACTION B: Dispatch Codex reviewer (product + spec compliance):
-|        $TIMEOUT_CMD 600 codex exec --full-auto "Read spec at [path]. Then run git diff [base]. Review for:
+|      ACTION B: Dispatch secondary provider reviewer (product + spec compliance):
+|        If Codex: $TIMEOUT_CMD 600 codex exec --full-auto "REVIEW_PROMPT" 2>&1
+|        If other provider: $TIMEOUT_CMD 600 <provider> <flags> "REVIEW_PROMPT" 2>&1
+|        If no provider: Agent(prompt="REVIEW_PROMPT", run_in_background=true)
+|        REVIEW_PROMPT = "Read spec at [path]. Then run git diff [base]. Review for:
 |          1. Spec compliance — does implementation match spec?
 |          2. Product: does it solve the user's problem?
 |          3. UX gaps: uncovered flows, edge cases
 |          4. Code quality: error handling, edge cases
-|          Return ACCEPTED or NEEDS_FIXES." 2>&1
+|          Return ACCEPTED or NEEDS_FIXES."
 |
 |      ACTION C: Wait for BOTH to return.
 |      ACTION D: If NEEDS_FIXES → fix → re-test → re-review.
 |      ACTION E: Only after ACCEPTED → create .par-evidence.json:
-|        echo '{"sprint":N,"claude":"ACCEPTED","codex":"ACCEPTED","ts":"'$(date -u +%FT%TZ)'"}' > .par-evidence.json
+|        echo '{"sprint":N,"reviewer_a":"ACCEPTED","reviewer_b":"ACCEPTED","provider":"'$SECONDARY_PROVIDER'","ts":"'$(date -u +%FT%TZ)'"}' > .par-evidence.json
 |      ACTION F: Proceed to step 7.
 |
 |      IF YOU ARE READING THIS AND THINKING "I'll skip it this time": that is
@@ -98,14 +101,14 @@ For each Sprint N:
 **Review optimization:**
 - Simple tasks (1-2 files, <50 lines): spec review only
 - Medium tasks (2-5 files): spec review + Claude code quality
-- Complex tasks (5+ files): full review cycle (spec + Claude + Codex + product)
+- Complex tasks (5+ files): full review cycle (spec + dual-model + product)
 
-**When Codex is unavailable** (not installed or `codex --version` fails):
+**When no secondary provider is available:**
 Do NOT skip the second reviewer. Instead, dispatch **two Claude agents** with split focus:
 - **Agent A (Technical):** security, architecture, performance, correctness, error handling
 - **Agent B (Product):** spec compliance, UX gaps, edge cases, data integrity
 Both run in parallel via Agent tool with `run_in_background: true`.
-Record evidence as: `{"claude_technical":"ACCEPTED","claude_product":"ACCEPTED",...}`
+Record evidence as: `{"reviewer_a":"ACCEPTED","reviewer_b":"ACCEPTED","provider":"split-focus",...}`
 
 ## Git Worktree Rules
 


### PR DESCRIPTION
## Summary

Makes the review architecture provider-agnostic while keeping Codex as the **preferred** secondary provider.

## Motivation

v1.3.0 добавил отличный split-focus fallback когда Codex недоступен. Этот PR развивает идею дальше: вместо жёсткой привязки "Codex или fallback" — универсальная архитектура с цепочкой провайдеров.

**Зачем это нужно:**
- Не у всех есть Codex / OpenAI API key
- Gemini CLI бесплатен и уже стабилен
- Aider поддерживает десятки моделей
- Будущие CLI-провайдеры подключатся автоматически
- Для пользователей с Codex **ничего не меняется** — он остаётся preferred

## Fallback chain

```
1. Codex (preferred) — best cross-model diversity, recommended
2. Other CLI provider (Gemini CLI, Aider, etc.) — auto-detected at startup
3. Split-focus Claude (last resort) — two agents with different review lenses
```

Detection at startup via smoke test:
```bash
codex --version 2>/dev/null && SECONDARY_PROVIDER="codex"
[ -z "$SECONDARY_PROVIDER" ] && gemini --version 2>/dev/null && SECONDARY_PROVIDER="gemini"
[ -z "$SECONDARY_PROVIDER" ] && aider --version 2>/dev/null && SECONDARY_PROVIDER="aider"
```

## What changes

| File | Change |
|------|--------|
| `SKILL.md` | Secondary provider detection, fallback chain in rules/checklist, renamed "Codex Integration" → "Secondary Provider Integration" |
| `references/phase1-discovery.md` | Provider-agnostic product expert + spec/plan review |
| `references/phase2-execution.md` | Provider-agnostic PAR actions, evidence JSON with `provider` field |
| `prompts/code-quality-reviewer.md` | "Secondary Provider Review" + "Split-Focus Fallback" sections |
| `prompts/product-reviewer.md` | Same pattern |
| `README.md` | Updated descriptions, requirements, model strategy table |

## What stays the same

- Codex is still **primary and recommended**
- `bypassPermissions` untouched
- All existing Codex invocation patterns preserved in prompt templates
- `$TIMEOUT_CMD` pattern from v1.3.0 preserved
- No behavioral changes for users who have Codex installed
- PAR enforcement logic unchanged

## Test plan

- [ ] User with Codex installed → detection picks Codex, all reviews use Codex (no change)
- [ ] User with Gemini CLI only → detection picks Gemini, reviews use Gemini
- [ ] User with no secondary provider → split-focus Claude fallback activates
- [ ] Verify `.par-evidence.json` includes `provider` field