### PR TITLE
fix: greenfield detection based on source_count, not file_count

### DIFF
--- a/references/phase0/greenfield.md
+++ b/references/phase0/greenfield.md
@@ -11,9 +11,10 @@ This file is re-read after context compaction. Re-read it if you lose context.
 ## When This Path Is Active
 
 Stage 1 detects greenfield when:
-- Fewer than 5 source files exist (excluding dotfiles and config)
-- No `src/`, `lib/`, or `app/` directory with actual code
-- No package.json, pyproject.toml, go.mod, or Cargo.toml present
+- Zero source files exist (`.js`, `.ts`, `.py`, `.rb`, `.go`, `.rs`)
+- No manifest files present (package.json, pyproject.toml, go.mod, Cargo.toml, Gemfile)
+
+A repo may have docs, CI configs, issue templates, and many commits — it is still greenfield if there is no application code and no manifest.
 
 If detected, skip Stage 2 (analysis), Stage 3 (proposal), and Stage 4 Branch A (docs).
 Enter at Step G1 below. After G6, rejoin at Stage 4 Branch B.

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -128,11 +128,11 @@ Compile results into a dict. Example shape:
 
 Check for manifest files: `ls package.json pyproject.toml go.mod Cargo.toml Gemfile 2>/dev/null`
 
-If (`file_count=0` AND `source_count=0` AND no manifest files) OR (`file_count≤5` AND `commit_count≤2` AND `source_count=0` AND no manifest files):
+If `source_count=0` AND no manifest files:
 
-This is a greenfield or near-empty project (e.g., only README.md + LICENSE, no manifests). Tell the user: "This looks like a new project! I'll help set up the foundation." → load and follow `references/phase0/greenfield.md`. Do not proceed with the steps below.
+This is a greenfield project — there is no application code regardless of how many docs, CI configs, or commits exist. Tell the user: "This looks like a new project! I'll help set up the foundation." → load and follow `references/phase0/greenfield.md`. Do not proceed with the steps below.
 
-> **Not greenfield:** A repo with manifest files (package.json, pyproject.toml, etc.) but no source code is treated as an existing project — the user already chose a stack.
+> **Not greenfield:** A repo with manifest files (package.json, pyproject.toml, etc.) but no source code is treated as an existing project — the user already chose a stack and scaffolding is partially done.
 
 ---
 


### PR DESCRIPTION
## Summary
- Repos with docs/CI/issue templates but zero source code were misclassified as "existing projects", causing Phase 0 to launch 5 analysis agents on an empty codebase
- Simplified greenfield condition to `source_count=0 AND no manifest files` — removes meaningless `file_count` and `commit_count` thresholds
- Aligned `greenfield.md` "When This Path Is Active" section with the new detection logic

## Test plan
- [ ] Run Superflow on a repo with docs/CI but no source code (e.g. only README, LICENSE, .github/) — should route to greenfield path
- [ ] Run Superflow on a repo with `pyproject.toml` but no source code — should NOT route to greenfield (manifest exists)
- [ ] Run Superflow on a normal existing project — no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)