### PR TITLE
feat: anti-regression hardening — effort bumps, MAX_THINKING_TOKENS, rule 8a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to superflow will be documented in this file.
 
+## [4.5.0] - 2026-04-15
+
+### Changed — Anti-Regression Effort Bumps
+- **Context**: Anthropic confirmed two regression-causing changes to Claude Code in Feb-Mar 2026: (1) adaptive thinking made the model self-pace reasoning length per turn, sometimes producing zero-thinking turns even at `effort=high`; (2) the default effort level was lowered from `high` to `medium`. See [issue #42796](https://github.com/anthropics/claude-code/issues/42796) and the [bcherny HN reply](https://news.ycombinator.com/item?id=47664442). Independent benchmarks (@Frisch12) show `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` covers only 1 of 5 adaptive code-paths in the cli — subagent paths via `V9H()` still ignore the env var. The legal lever for subagents is the `effort:` frontmatter in `~/.claude/agents/*.md` files
+- **deep-* agents**: `effort: high` → `effort: max`. Affects `deep-analyst`, `deep-code-reviewer`, `deep-doc-writer`, `deep-implementer`, `deep-product-reviewer`, `deep-spec-reviewer`. Used in Phase 0 audit, Phase 1 spec review, Phase 2 final holistic review, and llms.txt/CLAUDE.md generation
+- **standard-* agents**: `effort: medium` → `effort: high`. Affects `standard-code-reviewer`, `standard-doc-writer`, `standard-implementer`, `standard-product-reviewer`, `standard-spec-reviewer`. Used in per-sprint unified review, plan review, and Phase 3 doc updates
+- **fast-implementer**: unchanged at `effort: low` (intentionally cheap for CRUD/config/file-move tasks)
+- **Trade-off**: higher token spend per sprint and higher latency in exchange for guaranteed reasoning depth. Particularly important for SuperFlow because subagents (where most code is written and reviewed) cannot fall back to keyword triggers like `ultrathink` — those are detected only on the main user prompt
+
+### Added — Anti-Bypass CI Rule (8a)
+- **Rule 8a**: NEVER use `gh pr merge --admin`. After every `gh pr create`, run `gh run list` and wait for CI green before merging. If CI fails, investigate via `gh run view <id> --log-failed`, fix, push, wait for green
+- **Rationale**: branch protection exists for a reason. Bypassing CI with `--admin` defeats the entire dual-model review and verification discipline that PAR is built on
+- **Rationalization Prevention**: added two new traps to the prevention list — "CI is broken but my tests pass locally" → fix CI first; "I'll use --admin to bypass CI" → NEVER
+
+### Recommended — settings.json env vars
+For users running SuperFlow on Claude Code 2.1.108+, add to `~/.claude/settings.json`:
+```json
+{ "env": {
+    "CLAUDE_CODE_EFFORT_LEVEL": "max",
+    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+    "MAX_THINKING_TOKENS": "63999",
+    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
+}, "showThinkingSummaries": true }
+```
+`MAX_THINKING_TOKENS` is only honored when `DISABLE_ADAPTIVE_THINKING=1` is set (adaptive nullifies it — see [claude-agent-sdk#168](https://github.com/anthropics/claude-agent-sdk-typescript/issues/168)). `AUTO_COMPACT_WINDOW=400000` keeps the working context tight enough that CLAUDE.md and SuperFlow rules don't get drowned out in 1M-context sessions.
+
 ## [4.4.0] - 2026-03-29
 
 ### Added — Sprint-Level Parallel Execution

--- a/agents/deep-analyst.md
+++ b/agents/deep-analyst.md
@@ -2,7 +2,7 @@
 name: deep-analyst
 description: "Deep analysis agent for Phase 0 codebase audit (shared by all 4 analyst roles)"
 model: opus
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/deep-code-reviewer.md
+++ b/agents/deep-code-reviewer.md
@@ -2,7 +2,7 @@
 name: deep-code-reviewer
 description: "Deep code quality review — correctness, security, performance for critical reviews"
 model: opus
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/deep-doc-writer.md
+++ b/agents/deep-doc-writer.md
@@ -2,7 +2,7 @@
 name: deep-doc-writer
 description: "Documentation generation agent for llms.txt and CLAUDE.md (Phase 0 first-time creation)"
 model: opus
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/deep-implementer.md
+++ b/agents/deep-implementer.md
@@ -2,7 +2,7 @@
 name: deep-implementer
 description: "Deep implementation agent for complex tasks (new architecture, security-sensitive)"
 model: sonnet
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/deep-product-reviewer.md
+++ b/agents/deep-product-reviewer.md
@@ -2,7 +2,7 @@
 name: deep-product-reviewer
 description: "Deep product acceptance review for critical reviews"
 model: opus
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/deep-spec-reviewer.md
+++ b/agents/deep-spec-reviewer.md
@@ -2,7 +2,7 @@
 name: deep-spec-reviewer
 description: "Deep spec compliance and security review for critical reviews (Phase 1 spec review, Phase 2 final holistic)"
 model: opus
-effort: high
+effort: max
 ---
 
 <role>

--- a/agents/standard-code-reviewer.md
+++ b/agents/standard-code-reviewer.md
@@ -2,7 +2,7 @@
 name: standard-code-reviewer
 description: "Standard code quality review for per-sprint unified review"
 model: opus
-effort: medium
+effort: high
 ---
 
 <role>

--- a/agents/standard-doc-writer.md
+++ b/agents/standard-doc-writer.md
@@ -2,7 +2,7 @@
 name: standard-doc-writer
 description: "Documentation update agent for incremental doc updates (Phase 3)"
 model: opus
-effort: medium
+effort: high
 ---
 
 <role>

--- a/agents/standard-implementer.md
+++ b/agents/standard-implementer.md
@@ -2,7 +2,7 @@
 name: standard-implementer
 description: "Standard implementation agent for medium-complexity tasks"
 model: sonnet
-effort: medium
+effort: high
 ---
 
 <role>

--- a/agents/standard-product-reviewer.md
+++ b/agents/standard-product-reviewer.md
@@ -2,7 +2,7 @@
 name: standard-product-reviewer
 description: "Standard product review for per-sprint unified review"
 model: opus
-effort: medium
+effort: high
 ---
 
 <role>

--- a/agents/standard-spec-reviewer.md
+++ b/agents/standard-spec-reviewer.md
@@ -2,7 +2,7 @@
 name: standard-spec-reviewer
 description: "Standard spec compliance review for per-sprint unified review and plan review"
 model: opus
-effort: medium
+effort: high
 ---
 
 <role>

--- a/superflow-enforcement.md
+++ b/superflow-enforcement.md
@@ -18,6 +18,7 @@ Survives context compaction. SKILL.md does not.
 6. **Dual-model reviews: specialize, don't duplicate.** Claude = Product lens (spec fit, user scenarios, data integrity). Secondary = Technical lens (correctness, security, architecture). No overlapping roles.
 7. **No secondary provider = two Claude agents.** Product (product-reviewer) + Technical (code-quality-reviewer).
 8. **One PR per sprint.** Execute silently after plan approval.
+8a. **NEVER `gh pr merge --admin`.** If CI is red, fix CI first. After every `gh pr create`, run `gh run list` and wait for CI green before merging. If CI fails, investigate with `gh run view <id> --log-failed`, fix, push, wait for green.
 9. **Final Holistic Review — conditional.** Required when: ≥4 sprints, parallel execution, or governance_mode="critical". Skip for ≤3 linear sequential sprints in light/standard mode. When required: two reviewers (Claude deep-product + Codex high technical, or 2 split-focus Claude) review ALL code as a unified system. Fix CRITICAL/HIGH before Completion Report.
 10. **Governance mode fixed for the run.** Replanner adjusts sprint scope, not governance mode. Once selected in Phase 1 Step 2, the mode persists through all sprints in the run.
 
@@ -62,6 +63,8 @@ If you think any of these, STOP and do the thing:
 - "This sprint is too small for PAR" → run PAR
 - "Per-sprint PAR is enough" → check if holistic is required (Rule 9 conditions)
 - "I'll just git merge locally" → use `gh pr merge --rebase --delete-branch`
+- "CI is broken but my tests pass locally" → fix CI first, then merge
+- "I'll use --admin to bypass CI" → NEVER. Fix the CI failure. Branch protection is there for a reason.
 
 ## Product Approval Gate
 


### PR DESCRIPTION
## Summary

- **deep-* agents**: `effort: high` → `effort: max` (analyst, code-reviewer, doc-writer, implementer, product-reviewer, spec-reviewer)
- **standard-* agents**: `effort: medium` → `effort: high` (code-reviewer, doc-writer, implementer, product-reviewer, spec-reviewer)
- **fast-implementer**: unchanged at `effort: low`
- **Rule 8a** added: never use `gh pr merge --admin`; wait for CI green; investigate failures via `gh run view --log-failed`
- **CHANGELOG**: 4.5.0 entry with regression context, sources, and recommended `~/.claude/settings.json` env vars

## Why

Anthropic confirmed two regression-causing changes to Claude Code in Feb-Mar 2026 (see [issue #42796](https://github.com/anthropics/claude-code/issues/42796), [bcherny HN reply](https://news.ycombinator.com/item?id=47664442)):

1. **Adaptive thinking** (Feb 9, with Opus 4.6) — model self-paces reasoning per turn; produces zero-thinking turns even at `effort=high`
2. **Default effort lowered** (Mar 3) from `high` to `medium`

Behavioral symptoms:
- reads-per-edit dropped from 6.6 → 2.0 (Stella Laurenzo / AMD log analysis of 6,852 sessions)
- doubling of full-rewrites instead of targeted edits
- "I give up" / premature-stop hook fired 173× in 17 days vs. 0 previously

The official workaround `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1` covers only **1 of 5** `type:"adaptive"` paths in cli.js (per @Frisch12 binary analysis). Subagent paths via `V9H()` still ignore the env var. Since SuperFlow runs **all** code through subagents (Rule 1), the env var alone does not protect SuperFlow workflows.

The only legal lever for subagents is the `effort:` frontmatter in `~/.claude/agents/*.md`. Frontmatter overrides session-level effort. This PR sets that lever to the highest meaningful values for each agent tier.

Rule 8a closes a related anti-regression hole on the merge side: bypassing CI with `--admin` defeats the dual-model review and verification discipline that PAR is built on.

## Trade-offs

- **+** Guaranteed reasoning depth on subagent paths unreachable by env-var workarounds or `ultrathink` keyword (which only triggers on the main user prompt, event `tengu_ultrathink`)
- **−** Higher token spend per sprint and higher latency
- **Mitigation**: fast-implementer kept at `effort: low` for genuinely cheap CRUD/config tasks

## Recommended companion settings (for users, in CHANGELOG)

```json
{
  "env": {
    "CLAUDE_CODE_EFFORT_LEVEL": "max",
    "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
    "MAX_THINKING_TOKENS": "63999",
    "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
  },
  "showThinkingSummaries": true
}
```

`MAX_THINKING_TOKENS` is only honored when `DISABLE_ADAPTIVE_THINKING=1` (adaptive nullifies it — see [claude-agent-sdk#168](https://github.com/anthropics/claude-agent-sdk-typescript/issues/168)).

## Test plan

- [ ] Run a critical-mode SuperFlow on a small repo and verify `effort: max` is honored in subagent invocations
- [ ] Verify `MAX_THINKING_TOKENS=63999` activates fixed budget on main thread
- [ ] Confirm Rule 8a wording propagates correctly through context compaction (re-read at sprint boundary per Rule 5)
- [ ] Spot-check token usage delta vs. previous version on an equivalent feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)