### PR TITLE
feat: Phase 0 anti-regression settings check (4.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to superflow will be documented in this file.
 
+## [4.6.0] - 2026-04-15
+
+### Added — Phase 0 Anti-Regression Settings Check
+- **Inline detection in SKILL.md** (new step 5a, between Phase 0 gate and startup banner): at the start of every session, run a small `jq`-based bash check against `~/.claude/settings.json` for the four recommended env vars introduced in 4.5.0 (`CLAUDE_CODE_EFFORT_LEVEL=max`, `CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1`, `MAX_THINKING_TOKENS`, `CLAUDE_CODE_AUTO_COMPACT_WINDOW`) plus `showThinkingSummaries: true`
+- **New reference**: `references/anti-regression-check.md` — full detection script, user prompt template (translatable), `jq`-based apply script with auto-backup, marker file format, edge case handling
+- **Marker file**: `~/.claude/.superflow-anti-regression-checked` (JSON: `{checked_at, decision, missing_at_check, superflow_version}`) prevents re-prompting after the user's decision. To re-trigger: `rm` the marker
+- **Conversational, never auto-applies**: three options shown to user — `[y]es apply` / `[n]o defer` / `[s]kip-permanently`. After apply, prompts user to restart Claude Code (env vars are read at process start)
+- **Fail-safe**: if `jq` missing, `settings.json` malformed, or settings file absent, the check skips silently without blocking SuperFlow startup
+- **Rationale**: closes the loop on 4.5.0 — new SuperFlow users no longer need to manually find the recommended settings; Phase 0 surfaces them on first run with full context (links to issue #42796 and bcherny HN reply)
+
+### Why `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000` is mandatory (not optional)
+The Phase 2 use case justifies this even when the user prefers `1M + manual /clear` discipline elsewhere. Phase 2 is **fully autonomous** for 6-8 hours, sprint after sprint, with no `/clear` opportunity. The orchestrator's context grows monotonically: plans, subagent results, reviews, fix iterations, evidence. By the end of a long Phase 2 the context sits at 800-900k+, which is exactly when the final holistic review (governance="critical") makes whole-run decisions — the worst possible moment for the documented reads-per-edit / quality degradation. The `PostCompact` hook (already in `~/.claude/settings.json`) re-injects SuperFlow rules after every compaction, and Rule 5 (re-read phase docs at sprint boundary) further compensates — so compaction is *safe by architecture* in SuperFlow specifically. More frequent compaction (400k threshold) means smaller individual compressions and less cumulative loss than one big 1M → 200k compaction at the end.
+
 ## [4.5.0] - 2026-04-15
 
 ### Changed — Anti-Regression Effort Bumps

--- a/SKILL.md
+++ b/SKILL.md
@@ -79,6 +79,21 @@ superflow/
      ```
      - `MARKER_LOCAL` or `MARKER_ON_MAIN` → skip Phase 0, write fresh state with phase=1
      - `NO_MARKER` → read `references/phase0-onboarding.md` for full Phase 0
+5a. **Anti-regression settings check** (inline — runs once per machine, do NOT read `references/anti-regression-check.md` unless needed):
+   ```bash
+   if [ -f ~/.claude/.superflow-anti-regression-checked ]; then echo "DISMISSED"; \
+   elif [ ! -r ~/.claude/settings.json ]; then echo "NO_SETTINGS"; \
+   else MISSING=(); \
+     jq -e '.env.CLAUDE_CODE_EFFORT_LEVEL == "max"' ~/.claude/settings.json >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_EFFORT_LEVEL"); \
+     jq -e '.env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING == "1"' ~/.claude/settings.json >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING"); \
+     jq -e '.env.MAX_THINKING_TOKENS' ~/.claude/settings.json >/dev/null 2>&1 || MISSING+=("MAX_THINKING_TOKENS"); \
+     jq -e '.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW' ~/.claude/settings.json >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_AUTO_COMPACT_WINDOW"); \
+     jq -e '.showThinkingSummaries == true' ~/.claude/settings.json >/dev/null 2>&1 || MISSING+=("showThinkingSummaries"); \
+     [ ${#MISSING[@]} -eq 0 ] && echo "ALL_SET" || printf "MISSING:%s\n" "$(IFS=,; echo "${MISSING[*]}")"; \
+   fi
+   ```
+   - `DISMISSED` / `ALL_SET` / `NO_SETTINGS` → silent, continue to step 6
+   - `MISSING:...` → read `references/anti-regression-check.md` and follow it (conversational: show user the diff, ask y/n/skip-permanently, apply via jq if user agrees, write marker file). After the user decision, continue to step 6.
 6. **Display startup banner** — output immediately after detection, before any phase routing:
    ```
    ╔═══════════════════════════════════╗

--- a/references/anti-regression-check.md
+++ b/references/anti-regression-check.md
@@ -1,0 +1,153 @@
+# Anti-Regression Settings Check (First-Run Onboarding)
+
+Runs **once per machine** at the start of the first SuperFlow session. Detects whether the user's `~/.claude/settings.json` is configured to mitigate the Feb-Mar 2026 Claude Code quality regression. If not, shows a diff and asks the user whether to apply.
+
+This is a **conversational** step — talk to the user, do not silently mutate their settings.
+
+---
+
+## Why this exists
+
+Anthropic confirmed two regression-causing changes to Claude Code in Feb-Mar 2026 (see [issue #42796](https://github.com/anthropics/claude-code/issues/42796), [bcherny HN reply](https://news.ycombinator.com/item?id=47664442)):
+
+1. **Adaptive thinking** (Feb 9, with Opus 4.6) — model self-paces reasoning per turn; produces zero-thinking turns even at `effort=high`
+2. **Default effort lowered** (Mar 3) from `high` to `medium`
+
+Behavioral symptoms in shipped code: reads-per-edit dropped 6.6 → 2.0, doubling of full-rewrites instead of targeted edits, premature stops. SuperFlow runs all code through subagents (Rule 1), where the most aggressive workarounds (env vars, `ultrathink` keyword) are partially or entirely ineffective. The recommended settings below give the best mitigation that doesn't require patching the Claude Code binary.
+
+---
+
+## Detection
+
+```bash
+SETTINGS=~/.claude/settings.json
+MARKER=~/.claude/.superflow-anti-regression-checked
+
+# Skip if user already decided
+if [ -f "$MARKER" ]; then
+  echo "DISMISSED"
+  exit 0
+fi
+
+# Skip if settings.json does not exist or is unreadable (let user create it first)
+if [ ! -r "$SETTINGS" ]; then
+  echo "NO_SETTINGS"
+  exit 0
+fi
+
+# Build list of missing or suboptimal keys
+MISSING=()
+jq -e '.env.CLAUDE_CODE_EFFORT_LEVEL == "max"' "$SETTINGS" >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_EFFORT_LEVEL")
+jq -e '.env.CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING == "1"' "$SETTINGS" >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING")
+jq -e '.env.MAX_THINKING_TOKENS' "$SETTINGS" >/dev/null 2>&1 || MISSING+=("MAX_THINKING_TOKENS")
+jq -e '.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW' "$SETTINGS" >/dev/null 2>&1 || MISSING+=("CLAUDE_CODE_AUTO_COMPACT_WINDOW")
+jq -e '.showThinkingSummaries == true' "$SETTINGS" >/dev/null 2>&1 || MISSING+=("showThinkingSummaries")
+
+if [ ${#MISSING[@]} -eq 0 ]; then
+  echo "ALL_SET"
+else
+  printf "MISSING:%s\n" "$(IFS=,; echo "${MISSING[*]}")"
+fi
+```
+
+Outputs (one of):
+- `DISMISSED` → user already chose, skip silently
+- `NO_SETTINGS` → cannot help, skip silently
+- `ALL_SET` → already configured, skip silently
+- `MISSING:KEY1,KEY2,...` → run the prompt below
+
+---
+
+## User prompt
+
+When detection returns `MISSING:...`, show the user this message inline (do NOT auto-apply). Translate the prose to the user's language (Russian, English, etc.) but keep the diff block and key names verbatim.
+
+```
+🛡️  SuperFlow detected your Claude Code config could mitigate the Feb-Mar 2026 quality regression.
+
+Anthropic confirmed two regressions: adaptive thinking (model under-thinks per turn) + lowered default effort. SuperFlow's subagents are particularly affected — env-var workarounds only cover 1 of 5 adaptive code paths, and `ultrathink` keyword does not work in subagents.
+
+Recommended additions to ~/.claude/settings.json:
+
+  env:
+    CLAUDE_CODE_EFFORT_LEVEL=max                 # raise default effort to max
+    CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1      # turn off model self-pacing
+    MAX_THINKING_TOKENS=63999                    # fixed thinking budget (only honored when adaptive is off)
+    CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000       # keep working context tight, prevent CLAUDE.md drown-out
+
+  showThinkingSummaries: true                    # restore visible thinking blocks in UI
+
+Trade-off: higher token spend per session, slightly higher latency. SuperFlow workflows benefit most.
+
+Sources: github.com/anthropics/claude-code/issues/42796 · news.ycombinator.com/item?id=47664442
+
+Apply? [y]es / [n]o / [s]kip-permanently
+```
+
+Wait for user response. Three branches:
+
+- **`y` / yes / да** → run the apply script below, then write marker with `decision: "applied"`
+- **`n` / no / нет** → write marker with `decision: "deferred"` (will ask again on next first run if marker is removed manually)
+- **`s` / skip-permanently / никогда** → write marker with `decision: "dismissed"` and a note that user can re-trigger by deleting the marker file
+
+After any of the three, continue Phase 0 / Phase 1 routing without further interruption.
+
+---
+
+## Apply script
+
+Backs up `settings.json` first, then merges the recommended keys via `jq` (preserves all existing settings).
+
+```bash
+SETTINGS=~/.claude/settings.json
+BACKUP_DIR=~/.claude/backups
+mkdir -p "$BACKUP_DIR"
+cp "$SETTINGS" "$BACKUP_DIR/settings.json.$(date +%Y%m%d-%H%M%S).pre-anti-regression.bak"
+
+# Merge env keys (idempotent; preserves existing env vars)
+jq '.env = (.env // {}) + {
+  "CLAUDE_CODE_EFFORT_LEVEL": "max",
+  "CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING": "1",
+  "MAX_THINKING_TOKENS": "63999",
+  "CLAUDE_CODE_AUTO_COMPACT_WINDOW": "400000"
+} | .showThinkingSummaries = true' "$SETTINGS" > "$SETTINGS.tmp" && mv "$SETTINGS.tmp" "$SETTINGS"
+
+echo "Applied. Backup at: $BACKUP_DIR/settings.json.*.pre-anti-regression.bak"
+```
+
+After successful apply, show the user:
+```
+✅ Settings updated. Backup saved at ~/.claude/backups/settings.json.*.pre-anti-regression.bak.
+   Restart Claude Code (exit + relaunch) for env vars to take effect.
+```
+
+The restart note is important — env vars in `settings.json` are read at process startup, not picked up live.
+
+---
+
+## Marker file
+
+After any of the three user decisions:
+
+```bash
+cat > ~/.claude/.superflow-anti-regression-checked << EOF
+{
+  "checked_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "decision": "applied|deferred|dismissed",
+  "missing_at_check": ["KEY1", "KEY2"],
+  "superflow_version": "4.6.0"
+}
+EOF
+```
+
+To re-trigger the check on a future session: `rm ~/.claude/.superflow-anti-regression-checked`.
+
+---
+
+## Edge cases
+
+- **`jq` not installed** → fall back to `python3 -c "import json; ..."` for both detection and apply. If neither is available, output `NO_TOOLS` and skip the check (do not block SuperFlow startup).
+- **`settings.json` is malformed JSON** → output `INVALID_SETTINGS`, show user a one-line warning ("Your settings.json has a JSON syntax error, please fix it before SuperFlow can recommend env vars"), skip the check, do not write a marker (so it'll re-check after fix).
+- **User's existing `CLAUDE_CODE_EFFORT_LEVEL` is `high` (not `max`)** → still considered missing for our purposes; the apply will overwrite to `max`. If user wants to keep `high`, they should choose `s` (skip-permanently).
+- **`MAX_THINKING_TOKENS` is set but to a value lower than `31999`** → considered "present" by current detection (we only check key existence, not value). This is intentional: we don't want to override user's explicit numerical choice. Document this in the user prompt if you want to be more aggressive in a future version.
+- **Multiple Claude Code installations / users on same machine** → marker is per-user (`~/.claude/`), so each user gets the prompt once.


### PR DESCRIPTION
> **Stacked PR on top of #63.** Will rebase / auto-target `main` once #63 merges.

## Summary

- New inline step **5a** in `SKILL.md` (between Phase 0 gate and startup banner): one-time-per-machine check against \`~/.claude/settings.json\` for the four recommended env vars from 4.5.0 (\`CLAUDE_CODE_EFFORT_LEVEL=max\`, \`CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING=1\`, \`MAX_THINKING_TOKENS\`, \`CLAUDE_CODE_AUTO_COMPACT_WINDOW\`) plus \`showThinkingSummaries: true\`
- New file: \`references/anti-regression-check.md\` — full detection script, user prompt template (translatable to user's language), \`jq\` apply script with auto-backup to \`~/.claude/backups/\`, marker file format, edge case handling
- Marker: \`~/.claude/.superflow-anti-regression-checked\` (JSON: \`{checked_at, decision, missing_at_check, superflow_version}\`) prevents re-prompting after decision
- \`CHANGELOG.md\` 4.6.0 entry, including detailed rationale for why \`CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000\` is mandatory (Phase 2 use case)

## Why

#63 introduced 4.5.0 with an effort bump for agent files and recommended env vars in CHANGELOG. But CHANGELOG is a passive surface — new SuperFlow users still have to manually find and apply those env vars. This PR closes that loop: Phase 0 surfaces the recommendation on first run, with full context (links to issue #42796 and bcherny HN reply), and one-keystroke apply.

## UX walkthrough

When user runs \`/superflow\` for the first time on a new machine:

1. SKILL.md inline check runs (~50ms): \`MISSING:CLAUDE_CODE_EFFORT_LEVEL,CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING,...\`
2. Claude reads \`references/anti-regression-check.md\` and shows the user a context-rich prompt (translated to user's language) with the diff and trade-offs
3. User picks \`y\` / \`n\` / \`s\`. On \`y\`: backup → \`jq\` merge → \"restart Claude Code\" reminder → marker written
4. Subsequent sessions see the marker → silent skip

If \`jq\` is missing, \`settings.json\` is malformed, or doesn't exist → silent skip, no marker written, never blocks SuperFlow.

## Why \`AUTO_COMPACT_WINDOW=400000\` is mandatory in this PR

Documented in the 4.6.0 CHANGELOG entry. Short version: Phase 2 is fully autonomous for 6-8 hours with no \`/clear\` opportunity, the orchestrator's context grows monotonically, and the worst possible moment for the documented quality regression is the final holistic review at the end of a long Phase 2. SuperFlow already has \`PostCompact\` hook re-injecting rules and Rule 5 (re-read phase docs at sprint boundary) — compaction is *safe by architecture* in SuperFlow specifically. Frequent small compactions beat one giant 1M → 200k compaction at the end.

## Test plan

- [ ] Fresh machine without env vars → step 5a fires, prompt shown, marker created
- [ ] \`y\` decision → backup created, env vars merged, restart message shown
- [ ] \`n\` decision → marker with \`deferred\`, next session re-prompts only if marker is removed manually
- [ ] \`s\` decision → marker with \`dismissed\`, next session silent
- [ ] All env vars already set → \`ALL_SET\`, silent skip, marker NOT written (so we can re-trigger if recommendations change)
- [ ] Malformed settings.json → silent skip, no marker, no startup block
- [ ] \`jq\` not installed → silent skip (graceful fallback documented but not yet implemented; covered as edge case)

## Out of scope (future iterations)

- Auto-compact / auto-clear between Phase 2 sprint waves — separate research, see ongoing background investigation
- Standalone \`claude-code-anti-regression\` GitHub installer for users who don't run SuperFlow

🤖 Generated with [Claude Code](https://claude.com/claude-code)