### PR TITLE
feat: orchestrator tool budget (Rule 11, 4.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to superflow will be documented in this file.
 
+## [4.8.0] - 2026-04-15
+
+### Added — Orchestrator Tool Budget (Rule 11)
+- **New enforcement Rule 11** in `superflow-enforcement.md`: in Phase 2 the orchestrator does NOT use Read/Grep/Glob directly on source files larger than 50 lines, and does NOT use Bash for anything beyond status checks, state I/O, and short progress output. All code reading, codebase exploration, research, and investigation route to `deep-analyst` (or `standard-implementer` for lighter work) with a <2k-token summary expected in response
+- **New section in `references/phase2-execution.md`**: "Orchestrator Tool Budget" enumerates allowed direct tools (Bash status/state, Read <50 lines, TaskCreate/TaskUpdate, Agent), lists correct-delegation examples, and calls out the rare exceptions where a direct read beats a dispatch round-trip
+- **Two new rationalizations** in the prevention list: "I'll just quickly Read this file myself" → dispatch analyst; "It's just one Grep" → dispatch if result could be >50 lines or context is already >60% of budget
+- **Why**: orchestrator context grows monotonically through Phase 2. Every directly-Read 500-line file adds 500 lines to a context already holding plan, charter, state, PAR evidence, review output, and turn history. Subagents return summaries and discard their own context on exit. On a 6-8h autonomous run, consistent delegation is the difference between hitting auto-compact ~2x versus ~10x — and the quality of the final holistic review depends on the orchestrator still being coherent at sprint N
+
 ## [4.7.0] - 2026-04-15
 
 ### Added — PreCompact State Externalization

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -92,6 +92,36 @@ TaskCreate(
 
 ---
 
+## Orchestrator Tool Budget
+
+In Phase 2 the orchestrator coordinates; it does not investigate or read code itself. The orchestrator's allowed direct tools are:
+
+- **Bash for status:** `git status`, `git log --oneline -N`, `git diff --stat`, `gh run list`, `gh pr view`, `ls`, `pwd`, `which`, `date`, short `echo` / `printf` for progress
+- **Bash for state I/O:** writing/reading `.superflow-state.json`, `.par-evidence.json`, CHANGELOG appends, `.superflow/compact-log/` listings
+- **Read for short config/state files (<50 lines):** `package.json`, `.superflow-state.json`, `.par-evidence.json`, the specific sprint section of the plan
+- **TaskCreate / TaskUpdate** for per-sprint stage tracking
+- **Agent (Task) tool** to dispatch subagents
+
+Anything else — and **especially** reading source code, exploring directories, running test suites, parsing JSON outputs longer than a few lines — belongs in a `deep-analyst` subagent that returns a <2k-token summary. Give the subagent the question, not a list of files to read.
+
+**Why this matters.** Orchestrator context grows monotonically through Phase 2. Every Read of a 500-line file adds 500 lines to a context that is already holding plan, charter, sprint state, PAR evidence, dual-model review output, and accumulated turn-history. Subagents return summaries; their own contexts are discarded when they exit. On a 6-8h autonomous run, the difference between "read files directly" and "route through analysts" is the difference between hitting the auto-compact threshold 10x vs. 2x.
+
+**Examples of correct delegation:**
+
+- *"What does module X do?"* → dispatch `deep-analyst` with the question; expect a bulleted summary back.
+- *"Does the codebase already have a function that does Y?"* → dispatch analyst to Grep + Read candidates + return a single-line answer (name/path or "no").
+- *"Why is test Z failing?"* → dispatch analyst to read the test, failure output, and suspected source files; return the root cause in 2-3 sentences.
+
+Exceptions to the budget, when a direct read is cheaper than a dispatch round-trip:
+
+- Files the orchestrator has already Read in the current sprint (still in context).
+- Files < 50 lines where the full content is the answer (e.g. confirming a PR's `.par-evidence.json` format).
+- Single-line status outputs (`git status --short`, `gh run list --limit 3`).
+
+See enforcement Rule 11 for the durable, compaction-surviving version of this budget.
+
+---
+
 ## Parallel Dispatch within a Sprint
 
 When a sprint has multiple tasks, analyze them for parallelism before dispatching.

--- a/superflow-enforcement.md
+++ b/superflow-enforcement.md
@@ -21,6 +21,7 @@ Survives context compaction. SKILL.md does not.
 8a. **NEVER `gh pr merge --admin`.** If CI is red, fix CI first. After every `gh pr create`, run `gh run list` and wait for CI green before merging. If CI fails, investigate with `gh run view <id> --log-failed`, fix, push, wait for green.
 9. **Final Holistic Review — conditional.** Required when: ≥4 sprints, parallel execution, or governance_mode="critical". Skip for ≤3 linear sequential sprints in light/standard mode. When required: two reviewers (Claude deep-product + Codex high technical, or 2 split-focus Claude) review ALL code as a unified system. Fix CRITICAL/HIGH before Completion Report.
 10. **Governance mode fixed for the run.** Replanner adjusts sprint scope, not governance mode. Once selected in Phase 1 Step 2, the mode persists through all sprints in the run.
+11. **Orchestrator delegates investigation to subagents.** In Phase 2 the orchestrator does NOT use Read/Grep/Glob directly on source files larger than 50 lines, and does NOT use Bash for anything beyond: status checks (`git status`, `gh run list`, `gh pr view`, `ls`, `pwd`, `which`, `date`), state I/O (`.superflow-state.json`, `.par-evidence.json`, CHANGELOG appends), and short `echo`/`printf` for user-visible progress. Any code reading, codebase exploration, research, or investigation → dispatch `deep-analyst` (or `standard-implementer` for lighter work) and require a <2k-token summary in response. Raw file contents do not belong in the orchestrator's context. See `references/phase2-execution.md` § Orchestrator Tool Budget.
 
 ## Secondary Provider Invocation
 
@@ -65,6 +66,8 @@ If you think any of these, STOP and do the thing:
 - "I'll just git merge locally" → use `gh pr merge --rebase --delete-branch`
 - "CI is broken but my tests pass locally" → fix CI first, then merge
 - "I'll use --admin to bypass CI" → NEVER. Fix the CI failure. Branch protection is there for a reason.
+- "I'll just quickly Read this file myself" → dispatch `deep-analyst` with the specific question; take the summary back
+- "It's just one Grep" → if the result could be >50 lines or context is already >60% of budget, dispatch instead
 
 ## Product Approval Gate
 


### PR DESCRIPTION
## Summary

- `superflow-enforcement.md` — new **Rule 11**: in Phase 2 the orchestrator does NOT use Read/Grep/Glob directly on source files larger than 50 lines and does NOT use Bash for anything beyond status checks, state I/O, and short progress output. All code reading, codebase exploration, research, and investigation route to `deep-analyst` (or `standard-implementer`) with a <2k-token summary expected in response.
- Two new rationalizations in the prevention list: *"I'll just quickly Read this file myself"* → dispatch analyst; *"It's just one Grep"* → dispatch if result could be >50 lines or context is already >60% of budget.
- `references/phase2-execution.md` — new **"Orchestrator Tool Budget"** section early in the file, enumerating allowed direct tools (Bash status/state, Read <50 lines, TaskCreate/TaskUpdate, Agent), correct-delegation examples, and the rare exceptions where a direct read beats a dispatch round-trip.
- `CHANGELOG.md` 4.8.0 entry.

## Why

Pattern B from the auto-compact automation research. The orchestrator cannot `/compact` or `/clear` itself (verified: [anthropics/claude-code#17237](https://github.com/anthropics/claude-code/issues/17237), [#27441](https://github.com/anthropics/claude-code/issues/27441) — no API). The only architecturally clean way to keep Phase 2 orchestrator's context manageable through a 6-8h autonomous run is to push investigation into subagents whose contexts return only summaries.

SuperFlow already has Rule 1 ("subagents write all code") but that doesn't stop the orchestrator from Reading/Greping for context-building — which is exactly what bloats context across sprint boundaries. Rule 11 extends Rule 1 to investigation.

On a 6-8h run this is the difference between hitting auto-compact ~2x (with Rule 11 followed) versus ~10x (without). The quality of the final holistic review — often the most consequential step in the whole workflow — depends on the orchestrator still being coherent by sprint N.

## Test plan

- [x] Rule 11 added after Rule 10 in `superflow-enforcement.md`; no existing rules renumbered.
- [x] Two new entries in the Rationalization Prevention list (same file).
- [x] "Orchestrator Tool Budget" section added to `references/phase2-execution.md` before Parallel Dispatch, so it orients everything that follows.
- [x] CHANGELOG 4.8.0 entry mirrors the rule and cites the spec's rationale.
- [ ] Real Phase 2 run comparison (orchestrator context size with vs. without Rule 11) — deferred to post-merge manual verification, as in the spec.

## Independence from PR #66 (PreCompact hook)

- No shared files beyond `CHANGELOG.md`, and the CHANGELOG entries are distinct versions (4.7.0 vs 4.8.0), so whichever PR merges second only needs a trivial CHANGELOG rebase.
- `references/phase2-execution.md`: PR #66 adds a "Compaction Recovery" section near the end (before "Failure & Debugging"); this PR adds "Orchestrator Tool Budget" near the start (before "Parallel Dispatch"). Different regions; rebase-friendly.

## Out of scope

- Enforcing the budget programmatically (e.g., a hook that blocks orchestrator Bash calls). The orchestrator is the agent itself; the only enforcement surface is the Rules document it re-reads at sprint boundaries and after PostCompact.
- Re-scoping existing Phase 0 / Phase 1 direct reads. Those phases are explicitly user-interactive; Rule 11 is scoped to Phase 2 (autonomous).

## Checklist

- [x] ≤ 300 lines diff (41 insertions, 0 deletions).
- [x] Conventional commit.
- [x] Branched from `main`, not stacked on PR #66.
- [x] No `gh pr merge --admin` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)