### PR TITLE
feat: event log hardening (Run 2 Sprint 3, v5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to superflow will be documented in this file.
 MEDIUM/LOW event-log gaps identified in Sprint 3 coverage audit; not in scope for this sprint:
 
 - **MEDIUM:** `agent_id` correlation for parallel waves — H5 adds the dispatch/complete pair pattern with `SF_PARENT_ID`, but systematic propagation of agent IDs across wave boundaries (parent→child agent chains) is not yet implemented
-- **MEDIUM:** Phase 3 CI-abandon `pr.merge` semantics bug — when a PR is abandoned due to persistent CI failure, `pr.merge` is emitted before the merge attempt fails, which misreports a non-merged PR as merged; correct fix requires a separate `pr.abandon` event type or conditional emission
+- **LOW:** Phase 3 failed-merge telemetry — `pr.merge` emission on CI failure/abandon is now suppressed (fixed in Sprint 3 fix-pass); a dedicated `pr.abandon` or `pr.fail` event type for failed-merge telemetry is deferred to a future schema extension
 - **MEDIUM:** Phase 3 post-merge `test.run`/`test.result` emissions — the post-merge integration test run on `main` (after all PRs merged) lacks `sf_emit test.run` / `sf_emit test.result` instrumentation
 - **LOW:** Enforce complexity/verdict enums at emitter layer — `sf_emit` currently accepts any string value for `complexity` and `verdict`; validation is deferred to consumers; adding allowlist checks inside `sf_emit` would catch typos at source
 - **LOW:** Normalize shell var quoting for typed args (`sprint:int="$VAR"`) — some phase docs use unquoted `$VAR` in typed-arg position; safe in practice but inconsistent; a style pass would standardize to `sprint:int=$VAR` (no quotes needed for numeric vars) uniformly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to superflow will be documented in this file.
 
+## Deferred (Sprint 3 → future)
+
+MEDIUM/LOW event-log gaps identified in Sprint 3 coverage audit; not in scope for this sprint:
+
+- **MEDIUM:** `agent_id` correlation for parallel waves — H5 adds the dispatch/complete pair pattern with `SF_PARENT_ID`, but systematic propagation of agent IDs across wave boundaries (parent→child agent chains) is not yet implemented
+- **MEDIUM:** Phase 3 CI-abandon `pr.merge` semantics bug — when a PR is abandoned due to persistent CI failure, `pr.merge` is emitted before the merge attempt fails, which misreports a non-merged PR as merged; correct fix requires a separate `pr.abandon` event type or conditional emission
+- **MEDIUM:** Phase 3 post-merge `test.run`/`test.result` emissions — the post-merge integration test run on `main` (after all PRs merged) lacks `sf_emit test.run` / `sf_emit test.result` instrumentation
+- **LOW:** Enforce complexity/verdict enums at emitter layer — `sf_emit` currently accepts any string value for `complexity` and `verdict`; validation is deferred to consumers; adding allowlist checks inside `sf_emit` would catch typos at source
+- **LOW:** Normalize shell var quoting for typed args (`sprint:int="$VAR"`) — some phase docs use unquoted `$VAR` in typed-arg position; safe in practice but inconsistent; a style pass would standardize to `sprint:int=$VAR` (no quotes needed for numeric vars) uniformly
+- **LOW:** `run.start` charter field population on Phase 1→2 boundary — `run.start` schema allows an optional `charter` field (path to Autonomy Charter); currently emitted without it since the charter is generated at end of Phase 1 after `run.start` fires; fix requires either a `run.update` event type or re-emitting `run.start` at Phase 2 entry with charter path
+
 ## [5.2.0] - 2026-04-24
 
 ### Added — Git Workflow Modes + Codex Sprint Parallelism

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,5 +108,4 @@ SKILL.md (entry point, ~240 lines, auto-detects Claude/Codex runtime)
 - **Codex no PreCompact/PostCompact**: compaction recovery relies on Stop hook dumps + SessionStart re-injection + self-referential rule in AGENTS.md. Less reliable than Claude's hook-based recovery.
 - **Codex context ~258K**: 4x smaller than Claude's 1M. Long Phase 2 runs (4+ sprints) require session-per-wave/session-per-sprint strategy or aggressive /compact usage.
 - **Per-event-type key allowlist**: `sf_emit` validates key names against an identifier regex and the event type against a global allowlist, but does not yet validate which keys are legal per event type. Practical injection is blocked; semantic key validation deferred to a future sprint.
-- **Per-event-type key allowlist expanded**: `sf_emit` validates key names and event type against allowlists, but does not yet validate which keys are legal per event type. Semantic key validation deferred to a future sprint.
 <!-- updated-by-superflow:2026-04-20 -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ SKILL.md (entry point, ~240 lines, auto-detects Claude/Codex runtime)
 | `prompts/expert-panel.md` | Expert persona prompt — proposals, challenge, recommendation |
 | `prompts/llms-txt-writer.md` | llmstxt.org standard, no hard size limit |
 | `prompts/claude-md-writer.md` | Verified paths/commands, <200 lines target |
-| `tools/sf-emit.sh` | Source-safe bash library for emitting JSONL events; usage: `source tools/sf-emit.sh && sf_emit <type> key=val key:int=N key:bool=true` (207 lines) |
+| `tools/sf-emit.sh` | Source-safe bash library for emitting JSONL events; usage: `source tools/sf-emit.sh && sf_emit <type> key=val key:int=N key:bool=true` (356 lines) |
+| `hooks/precompact-state-externalization.sh` | PreCompact hook — sources sf-emit, emits `compact.pre`/`compact.post` events with absolute path to the dump file |
 | `templates/event-schema.json` | JSON Schema 2020-12 for all event types — envelope fields + 20 per-type data schemas, additive evolution policy (524 lines) |
 
 ## Conventions
@@ -107,5 +108,5 @@ SKILL.md (entry point, ~240 lines, auto-detects Claude/Codex runtime)
 - **Codex no PreCompact/PostCompact**: compaction recovery relies on Stop hook dumps + SessionStart re-injection + self-referential rule in AGENTS.md. Less reliable than Claude's hook-based recovery.
 - **Codex context ~258K**: 4x smaller than Claude's 1M. Long Phase 2 runs (4+ sprints) require session-per-wave/session-per-sprint strategy or aggressive /compact usage.
 - **Per-event-type key allowlist**: `sf_emit` validates key names against an identifier regex and the event type against a global allowlist, but does not yet validate which keys are legal per event type. Practical injection is blocked; semantic key validation deferred to a future sprint.
-- **flock/size cap for sf-emit.sh**: `O_APPEND` is atomic only up to `PIPE_BUF` (~4KB on Linux). Large events or concurrent writes could corrupt `.superflow/events.jsonl`. Fix: add `flock` or enforce a per-event size cap in `sf-emit.sh`.
+- **Per-event-type key allowlist expanded**: `sf_emit` validates key names and event type against allowlists, but does not yet validate which keys are legal per event type. Semantic key validation deferred to a future sprint.
 <!-- updated-by-superflow:2026-04-20 -->

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -34,7 +34,7 @@ Only then resume work.
 10. **Final Holistic Review — conditional.** Required when: ≥4 sprints, parallel execution, `git_workflow_mode` is `parallel_wave_prs` or `stacked_prs`, or governance_mode="critical". Skip for ≤3 linear sequential sprints in light/standard mode.
 11. **Governance mode fixed for the run.**
 12. **Orchestrator delegates investigation to subagents.** In Phase 2, orchestrator does NOT read source files >50 lines directly. Dispatch "deep-analyst" via spawn_agent and require a <2k-token summary. Exceptions: files <50 lines, state files, single-line status outputs.
-13. **Event emission on state transition.** Call `sf_emit <event> [key=value...]` at every meaningful state change: `phase.start`, `stage.start`, `stage.complete`, `sprint.start`, `sprint.complete`, `compact.pre`, `compact.post`. Run the preloader block at the top of every phase doc bash usage before calling `sf_emit`. If `sf_emit` is unavailable after the preloader, events are silently dropped (no-op fallback) — this is intentional and must never cause a script error.
+13. **Event emission on state transition.** Call `sf_emit <event> [key=value...]` at every meaningful state change: `phase.start`, `stage.start`, `stage.end`, `sprint.start`, `sprint.end`, `compact.pre`, `compact.post`. Run the preloader block at the top of every phase doc bash usage before calling `sf_emit`. If `sf_emit` is unavailable after the preloader, events are silently dropped (no-op fallback) — this is intentional and must never cause a script error.
 
 ## Claude Product Reviewer Invocation
 

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -34,6 +34,7 @@ Only then resume work.
 10. **Final Holistic Review — conditional.** Required when: ≥4 sprints, parallel execution, `git_workflow_mode` is `parallel_wave_prs` or `stacked_prs`, or governance_mode="critical". Skip for ≤3 linear sequential sprints in light/standard mode.
 11. **Governance mode fixed for the run.**
 12. **Orchestrator delegates investigation to subagents.** In Phase 2, orchestrator does NOT read source files >50 lines directly. Dispatch "deep-analyst" via spawn_agent and require a <2k-token summary. Exceptions: files <50 lines, state files, single-line status outputs.
+13. **Event emission on state transition.** Call `sf_emit <event> [key=value...]` at every meaningful state change: `phase.start`, `stage.start`, `stage.complete`, `sprint.start`, `sprint.complete`, `compact.pre`, `compact.post`. Run the preloader block at the top of every phase doc bash usage before calling `sf_emit`. If `sf_emit` is unavailable after the preloader, events are silently dropped (no-op fallback) — this is intentional and must never cause a script error.
 
 ## Claude Product Reviewer Invocation
 

--- a/hooks/precompact-state-externalization.sh
+++ b/hooks/precompact-state-externalization.sh
@@ -54,6 +54,9 @@ else
   export SUPERFLOW_RUN_ID
 fi
 
+# Set absolute events file path so sf_emit writes to the project dir regardless of hook PWD.
+export SUPERFLOW_EVENTS_FILE="$CWD/.superflow/events.jsonl"
+
 # Project-local dump for SuperFlow runs; home fallback otherwise.
 if [ -f "$CWD/.superflow-state.json" ]; then
   DUMP_DIR="$CWD/.superflow/compact-log"

--- a/hooks/precompact-state-externalization.sh
+++ b/hooks/precompact-state-externalization.sh
@@ -42,11 +42,17 @@ SESSION_ID="${SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-unknown}}"
 CWD="${CWD:-${CLAUDE_PROJECT_DIR:-${CLAUDE_CODE_CWD:-$PWD}}}"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 
-# Read SUPERFLOW_RUN_ID from state file if env unset; fall back to "unknown".
+# Read SUPERFLOW_RUN_ID from state file if env unset.
+# If run_id is missing or not a real UUID, install a no-op sf_emit to avoid
+# emitting schema-invalid events (run_id must be a UUID, not "unknown").
 if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f "$CWD/.superflow-state.json" ] && command -v jq >/dev/null 2>&1; then
-  SUPERFLOW_RUN_ID="$(jq -r '.context.run_id // "unknown"' "$CWD/.superflow-state.json" 2>/dev/null || echo "unknown")"
+  SUPERFLOW_RUN_ID="$(jq -r '.context.run_id // empty' "$CWD/.superflow-state.json" 2>/dev/null || true)"
 fi
-export SUPERFLOW_RUN_ID="${SUPERFLOW_RUN_ID:-unknown}"
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+else
+  export SUPERFLOW_RUN_ID
+fi
 
 # Project-local dump for SuperFlow runs; home fallback otherwise.
 if [ -f "$CWD/.superflow-state.json" ]; then

--- a/hooks/precompact-state-externalization.sh
+++ b/hooks/precompact-state-externalization.sh
@@ -6,6 +6,23 @@
 
 set -e
 
+# Source sf-emit.sh for event emission (runtime-aware discovery).
+# Try known install locations in order; fall back to no-op if not found.
+_SF_EMIT_SOURCED=0
+for _SF_EMIT_PATH in \
+  "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+  "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+  "$HOME/.agents/skills/superflow/tools/sf-emit.sh" \
+  "./tools/sf-emit.sh"; do
+  if [ -f "$_SF_EMIT_PATH" ]; then
+    # shellcheck source=/dev/null
+    . "$_SF_EMIT_PATH" && _SF_EMIT_SOURCED=1 && break
+  fi
+done
+if [ "$_SF_EMIT_SOURCED" -eq 0 ]; then
+  sf_emit() { return 0; }
+fi
+
 # Claude Code sends hook payload as JSON on stdin; env vars are a fallback
 # for older versions or manual invocation.
 INPUT=""
@@ -25,6 +42,12 @@ SESSION_ID="${SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-unknown}}"
 CWD="${CWD:-${CLAUDE_PROJECT_DIR:-${CLAUDE_CODE_CWD:-$PWD}}}"
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
 
+# Read SUPERFLOW_RUN_ID from state file if env unset; fall back to "unknown".
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f "$CWD/.superflow-state.json" ] && command -v jq >/dev/null 2>&1; then
+  SUPERFLOW_RUN_ID="$(jq -r '.context.run_id // "unknown"' "$CWD/.superflow-state.json" 2>/dev/null || echo "unknown")"
+fi
+export SUPERFLOW_RUN_ID="${SUPERFLOW_RUN_ID:-unknown}"
+
 # Project-local dump for SuperFlow runs; home fallback otherwise.
 if [ -f "$CWD/.superflow-state.json" ]; then
   DUMP_DIR="$CWD/.superflow/compact-log"
@@ -34,6 +57,8 @@ fi
 mkdir -p "$DUMP_DIR"
 
 DUMP_FILE="$DUMP_DIR/precompact-${TS}.md"
+
+sf_emit compact.pre dump_path="$DUMP_FILE" 2>/dev/null || true
 
 {
   echo "# Pre-Compact State Dump"
@@ -75,6 +100,8 @@ DUMP_FILE="$DUMP_DIR/precompact-${TS}.md"
     echo '```'
   fi
 } > "$DUMP_FILE"
+
+sf_emit compact.post dump_path="$DUMP_FILE" 2>/dev/null || true
 
 # Emit hookSpecificOutput so the orchestrator can find the dump after compaction.
 if command -v jq >/dev/null 2>&1; then

--- a/llms.txt
+++ b/llms.txt
@@ -57,7 +57,7 @@ Version: v5.2.0 (2026-04-24). MIT License.
 
 ## Tools & Schemas
 
-- [tools/sf-emit.sh](tools/sf-emit.sh): Source-safe bash library for JSONL event emission — `source tools/sf-emit.sh && sf_emit <type> key=val key:int=N key:bool=true key:json='...'`; validates type allowlist and key identifier regex (207 lines)
+- [tools/sf-emit.sh](tools/sf-emit.sh): Source-safe bash library for JSONL event emission — `source tools/sf-emit.sh && sf_emit <type> key=val key:int=N key:bool=true key:json='...'`; validates type allowlist and key identifier regex; concurrent-safe via flock, with threshold-based log rotation to archive/ (356 lines)
 - [templates/event-schema.json](templates/event-schema.json): JSON Schema 2020-12 defining the event envelope (`v`, `id`, `ts`, `run_id`, `type`, `data`, `instance_id`, `parent_id`) and 20 per-type data schemas; additive evolution policy (524 lines)
 - [templates/superflow-state-schema.json](templates/superflow-state-schema.json): JSON Schema for `.superflow-state.json` state file including the `context.run_id` field added in Run 2 Sprint 1
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ Version: v5.2.0 (2026-04-24). MIT License.
 
 - [SKILL.md](SKILL.md): Entry point — startup checklist (6 steps), provider detection, phase routing (~240 lines)
 - [superflow-enforcement.md](superflow-enforcement.md): 13 hard rules that survive context compaction — deployed to ~/.claude/rules/ (103 lines)
+- [codex/AGENTS.md](codex/AGENTS.md): Codex equivalent of superflow-enforcement.md — hard rules and agent behavior for Codex runtime (98 lines)
 - [CLAUDE.md](CLAUDE.md): Project instructions for Claude — architecture, key files table, conventions (~110 lines)
 - [README.md](README.md): Installation, usage, v4.1 features, permissions setup
 

--- a/references/phase0-onboarding.md
+++ b/references/phase0-onboarding.md
@@ -18,6 +18,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Runs once per project. Detects project state, routes to the correct stage file, and loads it via the Read tool.

--- a/references/phase0-onboarding.md
+++ b/references/phase0-onboarding.md
@@ -1,5 +1,11 @@
 # Phase 0: Onboarding (FIRST RUN — INTERACTIVE)
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Runs once per project. Detects project state, routes to the correct stage file, and loads it via the Read tool.
 This phase is **conversational** — talk to the user, don't just execute silently.
 

--- a/references/phase0-onboarding.md
+++ b/references/phase0-onboarding.md
@@ -1,9 +1,23 @@
 # Phase 0: Onboarding (FIRST RUN — INTERACTIVE)
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Runs once per project. Detects project state, routes to the correct stage file, and loads it via the Read tool.

--- a/references/phase0/greenfield.md
+++ b/references/phase0/greenfield.md
@@ -18,6 +18,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Loaded by Stage 1 when an empty or near-empty project is detected.

--- a/references/phase0/greenfield.md
+++ b/references/phase0/greenfield.md
@@ -1,5 +1,11 @@
 # Phase 0 — Greenfield Path
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Loaded by Stage 1 when an empty or near-empty project is detected.
 After completing G6, rejoin at Stage 4 (skip Branch A — docs already created in G5).
 Run Branch B (permissions/hooks) and Branch C (scaffolding) only.

--- a/references/phase0/greenfield.md
+++ b/references/phase0/greenfield.md
@@ -1,9 +1,23 @@
 # Phase 0 — Greenfield Path
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Loaded by Stage 1 when an empty or near-empty project is detected.

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -228,6 +228,8 @@ s['context'] = {'preflight': {'skipped': True}, 'skip_phase0': True}
 s['last_updated'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
 json.dump(s, open('.superflow-state.json', 'w'), indent=2)
 "
+```
+
 ```bash
 sf_emit stage.end stage=detect phase:int=0
 sf_emit phase.end phase:int=0 label="Onboarding"

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -64,9 +64,23 @@ TaskCreate(
 Before any detection, write `.superflow-state.json`:
 
 ```bash
-cat > .superflow-state.json << STATEEOF
-{"version":1,"phase":0,"phase_label":"Onboarding","stage":"detect","stage_index":0,"last_updated":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-STATEEOF
+python3 -c "
+import json, datetime, os, tempfile
+p='.superflow-state.json'
+s = json.load(open(p)) if os.path.exists(p) else {}
+s.update({
+    'version': 1,
+    'phase': 0,
+    'phase_label': 'Onboarding',
+    'stage': 'detect',
+    'stage_index': 0,
+    'last_updated': datetime.datetime.now(datetime.timezone.utc).isoformat(),
+})
+s.setdefault('context', {})
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(p) or '.', prefix='.superflow-state.', suffix='.tmp')
+with os.fdopen(fd, 'w') as f: json.dump(s, f, indent=2)
+os.replace(tmp, p)
+"
 sf_emit stage.start stage=detect phase:int=0
 ```
 

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -2,9 +2,23 @@
 <!-- Stage 1, Todos: parallel preflight, present confirmation, handle response -->
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Runs at Phase 0 entry. Detects project state automatically, presents a one-line summary for user confirmation, and routes to the correct path (existing project, greenfield, or skip).

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -1,6 +1,12 @@
 # Phase 0 — Stage 1: Detect & Confirm
 <!-- Stage 1, Todos: parallel preflight, present confirmation, handle response -->
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Runs at Phase 0 entry. Detects project state automatically, presents a one-line summary for user confirmation, and routes to the correct path (existing project, greenfield, or skip).
 
 **All documentation output in English.** Communicate with the user in their language.

--- a/references/phase0/stage1-detect.md
+++ b/references/phase0/stage1-detect.md
@@ -19,6 +19,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Runs at Phase 0 entry. Detects project state automatically, presents a one-line summary for user confirmation, and routes to the correct path (existing project, greenfield, or skip).

--- a/references/phase0/stage2-analysis.md
+++ b/references/phase0/stage2-analysis.md
@@ -1,6 +1,12 @@
 # Phase 0 — Stage 2: Analysis
 <!-- Stage 2, Todos: dispatch 5 agents, wait, cross-check synthesis -->
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Runs after Stage 1 confirms `$PREFLIGHT`. Dispatches 5 parallel specialized agents to audit the codebase, then cross-checks findings for consistency. Output is an internal evidence bundle saved to state for Stage 3.
 
 **All documentation output in English.** Communicate with the user in their language.

--- a/references/phase0/stage2-analysis.md
+++ b/references/phase0/stage2-analysis.md
@@ -2,9 +2,23 @@
 <!-- Stage 2, Todos: dispatch 5 agents, wait, cross-check synthesis -->
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Runs after Stage 1 confirms `$PREFLIGHT`. Dispatches 5 parallel specialized agents to audit the codebase, then cross-checks findings for consistency. Output is an internal evidence bundle saved to state for Stage 3.

--- a/references/phase0/stage2-analysis.md
+++ b/references/phase0/stage2-analysis.md
@@ -19,6 +19,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Runs after Stage 1 confirms `$PREFLIGHT`. Dispatches 5 parallel specialized agents to audit the codebase, then cross-checks findings for consistency. Output is an internal evidence bundle saved to state for Stage 3.

--- a/references/phase0/stage2-analysis.md
+++ b/references/phase0/stage2-analysis.md
@@ -86,6 +86,18 @@ sf_emit stage.start stage=analysis phase:int=0
 
 All five agents launch simultaneously with `run_in_background: true`. Include `$PREFLIGHT` in every prompt so agents adjust depth to the project's stack and team context.
 
+Before dispatching each agent, emit a dispatch event and capture its ID for correlation. After each agent returns, emit a complete event. Repeat this pair for all 5 agents:
+
+```bash
+# Pattern for each agent (repeat per agent, substituting agent_type, task, model):
+AGENT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+SF_PARENT_ID="$AGENT_ID" sf_emit agent.dispatch agent_type=deep-analyst task="Phase 0: architecture analysis" model=opus
+# Agent() call here (run_in_background: true)
+# After agent returns:
+sf_emit agent.complete role=architecture-analyst agent_id="$AGENT_ID"
+# On failure instead: sf_emit agent.fail role=architecture-analyst agent_id="$AGENT_ID"
+```
+
 ### Agent 1 — Architecture (deep-analyst)
 
 ```

--- a/references/phase0/stage3-report.md
+++ b/references/phase0/stage3-report.md
@@ -19,6 +19,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Re-read this file at the start of Stage 3. Context compaction during Stage 2 analysis erases prior content.

--- a/references/phase0/stage3-report.md
+++ b/references/phase0/stage3-report.md
@@ -2,9 +2,23 @@
 <!-- Stage 3, Todos: generate health report, show summary, get approval -->
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Re-read this file at the start of Stage 3. Context compaction during Stage 2 analysis erases prior content.

--- a/references/phase0/stage3-report.md
+++ b/references/phase0/stage3-report.md
@@ -1,6 +1,12 @@
 # Phase 0 — Stage 3: Report & Proposal
 <!-- Stage 3, Todos: generate health report, show summary, get approval -->
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Re-read this file at the start of Stage 3. Context compaction during Stage 2 analysis erases prior content.
 
 **State source of truth:** Read `.superflow-state.json` — do not rely on LLM context for `$PREFLIGHT` or agent results.

--- a/references/phase0/stage3-report.md
+++ b/references/phase0/stage3-report.md
@@ -182,6 +182,11 @@ Ask: "Which items would you like to include/exclude?" Then build `items` list fr
 
 ---
 
+If the user explicitly declines the proposal (no setup wanted, abandon onboarding):
+```bash
+sf_emit run.end status=blocked
+```
+
 ## Step 3.5 — Persist Approval to State
 
 ```bash

--- a/references/phase0/stage4-setup.md
+++ b/references/phase0/stage4-setup.md
@@ -19,6 +19,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Re-read this file at the start of Stage 4. Context compaction during Stage 3 erases prior content.

--- a/references/phase0/stage4-setup.md
+++ b/references/phase0/stage4-setup.md
@@ -1,6 +1,12 @@
 # Phase 0 — Stage 4: Documentation & Environment
 <!-- Stage 4, Todos: dispatch 3 branches, wait, validate, recommend skills/plugins -->
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Re-read this file at the start of Stage 4. Context compaction during Stage 3 erases prior content.
 
 **State source of truth:** Read `context.approval` from `.superflow-state.json` before dispatching any branch. Do not rely on LLM context.

--- a/references/phase0/stage4-setup.md
+++ b/references/phase0/stage4-setup.md
@@ -2,9 +2,23 @@
 <!-- Stage 4, Todos: dispatch 3 branches, wait, validate, recommend skills/plugins -->
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Re-read this file at the start of Stage 4. Context compaction during Stage 3 erases prior content.

--- a/references/phase0/stage5-completion.md
+++ b/references/phase0/stage5-completion.md
@@ -19,6 +19,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 This file is re-read after context compaction. Re-read it if you lose context.

--- a/references/phase0/stage5-completion.md
+++ b/references/phase0/stage5-completion.md
@@ -2,9 +2,23 @@
 <!-- Stage 5, Todos: write markers, persist tech debt, update state, show summary -->
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 This file is re-read after context compaction. Re-read it if you lose context.

--- a/references/phase0/stage5-completion.md
+++ b/references/phase0/stage5-completion.md
@@ -1,6 +1,12 @@
 # Phase 0 — Stage 5: Completion
 <!-- Stage 5, Todos: write markers, persist tech debt, update state, show summary -->
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 This file is re-read after context compaction. Re-read it if you lose context.
 
 **State at entry:** phase=0, stage="completion", stage_index=4

--- a/references/phase1-discovery.md
+++ b/references/phase1-discovery.md
@@ -1,5 +1,11 @@
 # Phase 1: Product Discovery (COLLABORATIVE)
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 ## Stage Structure
 
 Phase 1 has 5 stages. Use TaskCreate at each stage start, TaskUpdate as todos complete.

--- a/references/phase1-discovery.md
+++ b/references/phase1-discovery.md
@@ -174,7 +174,17 @@ In light mode, the charter body contains the sprint breakdown directly. Charter 
 
 **Skip this step in light mode** — proceed directly to Step 5 (Brainstorming).
 
-Dispatch **parallel background research** using the Agent tool (`run_in_background: true` for each):
+Dispatch **parallel background research** using the Agent tool (`run_in_background: true` for each).
+Emit dispatch/complete pairs around each agent (repeat per agent, substituting role/task/model):
+
+```bash
+# Pattern for research agents (repeat per agent):
+AGENT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+SF_PARENT_ID="$AGENT_ID" sf_emit agent.dispatch agent_type=research-agent task="Phase 1: domain best practices research" model=opus
+# Agent() call here (run_in_background: true)
+# After agent returns:
+sf_emit agent.complete role=research-agent agent_id="$AGENT_ID"
+```
 
 ```
 Agent(model: opus, description: "Domain best practices research", run_in_background: true)
@@ -217,7 +227,17 @@ Dispatch 3-4 parallel background agents, each with a distinct expert persona. Us
 | UX/Workflow Expert | "How does this feel to use?" | Interaction flow, remote UX, cognitive load |
 | Domain Expert | "What does the industry do?" | Best practices, standards, prior art |
 
-Dispatch all in parallel:
+Dispatch all in parallel. Emit dispatch/complete pairs around each agent (repeat per agent, substituting persona/focus):
+
+```bash
+# Pattern for expert panel agents (repeat per agent):
+AGENT_ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+SF_PARENT_ID="$AGENT_ID" sf_emit agent.dispatch agent_type=expert-panel task="Phase 1: Product GM brainstorm" model=opus
+# Agent() call here (run_in_background: true)
+# After agent returns:
+sf_emit agent.complete role=expert-panel agent_id="$AGENT_ID"
+```
+
 ```
 Agent(model: opus, effort: high, description: "Product GM expert panel", run_in_background: true)
   → use prompts/expert-panel.md with persona="Product GM", focus="User pain, adoption, competitive edge"
@@ -383,6 +403,10 @@ mcp__plugin_telegram_telegram__reply(chat_id: <chat_id from context>, text: "Pro
 - "go" / "approve" → proceed to Step 8 (Spec)
 - "fix ..." / "changes" → ask what to change, update, re-present
 - "restart" → go back to Step 5 (brainstorming)
+- User abandons / explicitly cancels Phase 1:
+  ```bash
+  sf_emit run.end status=blocked
+  ```
 
 ```bash
 sf_emit stage.end stage=product-approval phase:int=1
@@ -414,6 +438,11 @@ Create `docs/superflow/specs/` if it doesn't exist.
 
 Run two reviewers in parallel. Both reviewers receive the product brief AND the spec.
 
+```bash
+sf_emit review.start reviewer=product target="spec"
+sf_emit review.start reviewer=technical target="spec"
+```
+
 1. **Claude reviewer (PRODUCT lens)**: `Agent(subagent_type: "deep-product-reviewer", run_in_background: true, prompt: "Review this spec for product completeness, scope alignment, user story coverage. Spec: [SPEC TEXT]")`. Focus: product completeness, scope alignment, user story coverage.
 2. **Secondary provider (TECHNICAL lens)**: `$TIMEOUT_CMD 600 codex exec --full-auto -m gpt-5.5 -c model_reasoning_effort=high --ephemeral "Spec review. Check completeness, security, architecture against: [SPEC TEXT]" 2>&1` via Bash (`run_in_background: true`).
    No secondary provider = split-focus Claude: Product (`deep-product-reviewer`) + Technical (`deep-spec-reviewer`).
@@ -422,6 +451,12 @@ Run two reviewers in parallel. Both reviewers receive the product brief AND the 
 
 Wait for both. If either returns NEEDS_REVISION: fix issues, re-run both reviews.
 Both must return PASS to proceed.
+
+```bash
+# VERDICT: one of APPROVE, ACCEPTED, PASS, FAIL, NEEDS_FIXES, REQUEST_CHANGES
+sf_emit review.verdict reviewer=product verdict="$VERDICT"
+sf_emit review.verdict reviewer=technical verdict="$VERDICT"
+```
 
 ```bash
 sf_emit stage.end stage=spec phase:int=1
@@ -470,6 +505,11 @@ The orchestrator uses this to build a sprint dependency graph and dispatch indep
 
 Run two reviewers in parallel (same mechanism as Step 8):
 
+```bash
+sf_emit review.start reviewer=product target="plan"
+sf_emit review.start reviewer=technical target="plan"
+```
+
 1. **Claude reviewer (PRODUCT lens)**: `Agent(subagent_type: "standard-product-reviewer", run_in_background: true, prompt: "Review this plan for product feasibility, scope correctness, user value alignment. Plan: [PLAN TEXT]")`. Does the plan deliver user value? Is scope correct? Are priorities aligned with the brief?
 2. **Secondary provider (TECHNICAL lens)**: `$TIMEOUT_CMD 600 codex exec --full-auto -m gpt-5.5 -c model_reasoning_effort=high --ephemeral "Plan review. Check achievability, scoping, dependencies against: [PLAN TEXT]" 2>&1` via Bash (`run_in_background: true`). Are there missing tasks? Over-engineering? Does sprint ordering make sense?
    No secondary provider = split-focus Claude: Product (`standard-product-reviewer`) + Technical (`standard-spec-reviewer`).
@@ -477,6 +517,12 @@ Run two reviewers in parallel (same mechanism as Step 8):
 > **Reasoning:** Standard tier — plan review checks structure and feasibility, not deep architectural decisions.
 
 Both must APPROVE. If either returns NEEDS_REVISION: fix, re-review.
+
+```bash
+# VERDICT: one of APPROVE, ACCEPTED, PASS, FAIL, NEEDS_FIXES, REQUEST_CHANGES
+sf_emit review.verdict reviewer=product verdict="$VERDICT"
+sf_emit review.verdict reviewer=technical verdict="$VERDICT"
+```
 
 ```bash
 sf_emit stage.end stage=plan phase:int=1

--- a/references/phase1-discovery.md
+++ b/references/phase1-discovery.md
@@ -1,9 +1,23 @@
 # Phase 1: Product Discovery (COLLABORATIVE)
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 ## Stage Structure

--- a/references/phase1-discovery.md
+++ b/references/phase1-discovery.md
@@ -18,6 +18,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 ## Stage Structure

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -66,6 +66,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 ### State Management

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -48,6 +48,12 @@ Stage 6: "Ship"
   - "Send Telegram update"
 ```
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 ### State Management
 
 Initialize state at the start of Phase 2:
@@ -323,12 +329,6 @@ Never silently switch modes during Phase 2. If the selected mode becomes unsafe 
 ---
 
 ## Per-Sprint Flow
-
-```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
-```
 
 1. <!-- Stage 1: Setup, Todo 1 --> **Re-read** this file (`references/phase2-execution.md`), the **charter** (from `context.charter_file` in `.superflow-state.json`), AND the **specific sprint section** from the plan. Extract and paste the exact task list for this sprint into the implementer prompt — do NOT rely on LLM memory of the plan. The implementer must see every task, every file path, every expected behavior verbatim.
    **Immediately after re-reading:** emit `sprint.start` and `stage.start`, then emit heartbeat (see "Heartbeat Writes → At sprint start" above). Use the charter path from `context.charter_file` in state as `$CHARTER_FILE`.

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -49,9 +49,23 @@ Stage 6: "Ship"
 ```
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 ### State Management

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -73,9 +73,25 @@ fi
 Initialize state at the start of Phase 2:
 
 ```bash
-cat > .superflow-state.json << STATEEOF
-{"version":1,"phase":2,"phase_label":"Autonomous Execution","stage":"setup","stage_index":0,"sprint":1,"last_updated":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
-STATEEOF
+python3 -c "
+import json, datetime, os, tempfile
+p='.superflow-state.json'
+s = json.load(open(p)) if os.path.exists(p) else {}
+# Update phase/stage fields only; preserve context (run_id, charter_file, etc.)
+s['version'] = 1
+s['phase'] = 2
+s['phase_label'] = 'Autonomous Execution'
+s['stage'] = 'setup'
+s['stage_index'] = 0
+s['sprint'] = s.get('sprint', 1)
+s['last_updated'] = datetime.datetime.now(datetime.timezone.utc).isoformat()
+# Context block — merge, don't replace
+s.setdefault('context', {})
+# Atomic write
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(p) or '.', prefix='.superflow-state.', suffix='.tmp')
+with os.fdopen(fd, 'w') as f: json.dump(s, f, indent=2)
+os.replace(tmp, p)
+"
 sf_emit phase.start phase:int=2 label="Autonomous Execution"
 ```
 

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -56,6 +56,7 @@ Initialize state at the start of Phase 2:
 cat > .superflow-state.json << STATEEOF
 {"version":1,"phase":2,"phase_label":"Autonomous Execution","stage":"setup","stage_index":0,"sprint":1,"last_updated":"$(date -u +%Y-%m-%dT%H:%M:%SZ)"}
 STATEEOF
+sf_emit phase.start phase:int=2 label="Autonomous Execution"
 ```
 
 ### Heartbeat Writes
@@ -91,6 +92,7 @@ with os.fdopen(fd, 'w') as f:
     json.dump(s, f, indent=2)
 os.replace(tmp, state_file)
 " \"\$SPRINT_GOAL\" \"\$WORKTREE_PATH\" \"\$BRANCH_NAME\" \"\$CHARTER_FILE\"
+sf_emit heartbeat phase2_step="setup" sprint:int=$SPRINT_NUM
 # SPRINT_GOAL: one-line sprint description from plan
 # WORKTREE_PATH: e.g. .worktrees/sprint-1
 # BRANCH_NAME: e.g. feat/feature-sprint-1
@@ -121,6 +123,7 @@ with os.fdopen(fd, 'w') as f:
     json.dump(s, f, indent=2)
 os.replace(tmp, state_file)
 " \"\$NEXT_STAGE\" \"\$SPRINT_NUM\"
+sf_emit heartbeat phase2_step="$NEXT_STAGE" sprint:int=$SPRINT_NUM
 # NEXT_STAGE: one of setup | implementation | review | par | docs | ship
 # SPRINT_NUM: current sprint number (e.g., 1, 2, 3)
 # On resume: heartbeat.phase2_step is the authoritative source of current stage.
@@ -321,7 +324,11 @@ Never silently switch modes during Phase 2. If the selected mode becomes unsafe 
 
 ## Per-Sprint Flow
 
-> **Backward-compat guard:** All `sf_emit ...` snippets below assume `tools/sf-emit.sh` is sourced at session start (see SKILL.md Startup Checklist §4b). If sf_emit is not in scope, skip the emission silently — state writes remain authoritative.
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
 
 1. <!-- Stage 1: Setup, Todo 1 --> **Re-read** this file (`references/phase2-execution.md`), the **charter** (from `context.charter_file` in `.superflow-state.json`), AND the **specific sprint section** from the plan. Extract and paste the exact task list for this sprint into the implementer prompt — do NOT rely on LLM memory of the plan. The implementer must see every task, every file path, every expected behavior verbatim.
    **Immediately after re-reading:** emit `sprint.start` and `stage.start`, then emit heartbeat (see "Heartbeat Writes → At sprint start" above). Use the charter path from `context.charter_file` in state as `$CHARTER_FILE`.
@@ -623,7 +630,7 @@ To hydrate cleanly after compaction:
 
 If `.superflow/compact-log/` does not exist, the PreCompact hook isn't installed — continue without hydration and note it for the next onboarding cycle.
 
-**Event log note:** `compact.pre` and `compact.post` events are emitted automatically by `hooks/precompact-state-externalization.sh` — no `sf_emit` call needed here. The compact log dump already serves as the event evidence.
+**Event log note:** `compact.pre` is emitted by `hooks/precompact-state-externalization.sh` immediately before writing the dump file; `compact.post` is emitted immediately after the dump write succeeds. Both carry `dump_path` so consumers can locate the state snapshot.
 
 ## Failure & Debugging
 
@@ -692,6 +699,10 @@ For each feature group:
 - Known limitations or follow-ups
 
 **4. What's Next** — suggested next action: "Ready to merge — say 'merge' to start Phase 3"
+
+```bash
+sf_emit phase.end phase:int=2 label="Autonomous Execution"
+```
 
 ### Tone
 - Write for someone who will USE the product, not someone who reviewed the PRs

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -638,6 +638,9 @@ If `.superflow/compact-log/` does not exist, the PreCompact hook isn't installed
 2. Form a hypothesis before touching code.
 3. Targeted fix, then verify with the specific test, then the full suite.
 4. 3+ failed attempts on the same issue: likely architectural problem. Report BLOCKED with evidence, suggest rethinking approach.
+   ```bash
+   sf_emit run.end status=blocked
+   ```
 5. Agent blocked: re-dispatch with more context. 2 fails on same agent task = implement manually.
 6. Never stop to ask the user. Accumulate issues, report at end.
 

--- a/references/phase2-execution.md
+++ b/references/phase2-execution.md
@@ -420,6 +420,7 @@ Never silently switch modes during Phase 2. If the selected mode becomes unsafe 
    b. Codex technical reviewer:
       ```bash
       sf_emit review.start reviewer=technical target="Sprint $SPRINT_NUM diff"
+      sf_emit agent.dispatch agent_type=codex-technical-reviewer task="Sprint $SPRINT_NUM technical review" model=gpt-5.5
       ```
       `$TIMEOUT_CMD 600 codex exec review --base main -m gpt-5.5 -c model_reasoning_effort=high --ephemeral - < <(echo "SPEC_CONTEXT" | cat - prompts/codex/code-reviewer.md) 2>&1` (run_in_background)
 
@@ -561,8 +562,11 @@ Never silently switch modes during Phase 2. If the selected mode becomes unsafe 
 9. <!-- Stage 6: Ship, Todos 1-2 --> **Emit unified stage transition** (`$NEXT_STAGE=ship`, `$SPRINT_NUM=N`). **Push + PR/checkpoint**: verify `.par-evidence.json` exists with review verdicts passing. If this sprint creates a PR under the selected git workflow mode, `docs_update` must be `UPDATED` or `UNCHANGED` and `docs_review` must be `PASS`; push the mode-specific branch and create the mode-specific PR. In `solo_single_pr`, non-final sprints push checkpoint commits to the shared feature branch without creating a PR; the final sprint creates one PR after docs gates pass.
    ```bash
    sf_emit stage.start stage=ship phase:int=2
-   # After gh pr create succeeds:
-   sf_emit pr.create pr_number:int=$PR_NUM title="$PR_TITLE" branch=$BRANCH_NAME sprint:int=$SPRINT_NUM
+   # Gate pr.create on PR creation (solo_single_pr non-final sprints skip this)
+   if [ -n "${PR_NUM:-}" ]; then
+     sf_emit pr.create pr_number:int=$PR_NUM title="$PR_TITLE" branch=$BRANCH_NAME sprint:int=$SPRINT_NUM
+   fi
+   # Always emit sprint.end / stage.end regardless of PR creation
    sf_emit sprint.end sprint:int=$SPRINT_NUM total_sprints:int=$TOTAL_SPRINTS goal="$SPRINT_GOAL" complexity="$COMPLEXITY"
    sf_emit stage.end stage=ship phase:int=2
    ```

--- a/references/phase3-merge.md
+++ b/references/phase3-merge.md
@@ -18,6 +18,10 @@ if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
   SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
   [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
 fi
+# If run_id still unavailable after best-effort restore, install no-op to avoid set -e aborts
+if [ -z "${SUPERFLOW_RUN_ID:-}" ]; then
+  sf_emit() { return 0; }
+fi
 ```
 
 Triggered when user says "merge", "мёрдж", "мерж", or gives clear affirmative response (e.g., "go ahead", "do it", "yes") after the Completion Report.

--- a/references/phase3-merge.md
+++ b/references/phase3-merge.md
@@ -175,7 +175,8 @@ for each PR in sprint order:
   1. gh pr checks <number> — verify CI green
      - If CI failing, send Telegram (if MCP available):
        mcp__plugin_telegram_telegram__reply(chat_id: <chat_id>, text: "PR #N CI failed, investigating...")
-     - sf_emit pr.merge number:int=NNN method=rebase  # emitted before abandoning this PR due to CI failure
+     # NOTE: no event emitted on CI failure/abandon — pr.merge is reserved for successful merges.
+     # Failed-merge telemetry is TBD (see CHANGELOG deferred).
   2. gh pr merge <number> --rebase --delete-branch
      sf_emit pr.merge number:int=NNN method=rebase  # replace NNN with actual PR number
   3. If merge fails due to conflict:

--- a/references/phase3-merge.md
+++ b/references/phase3-merge.md
@@ -1,5 +1,11 @@
 # Phase 3: Merge (USER-INITIATED)
 
+```bash
+# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
+# This ensures sessions without events.jsonl still work (charter non-negotiable).
+command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+```
+
 Triggered when user says "merge", "мёрдж", "мерж", or gives clear affirmative response (e.g., "go ahead", "do it", "yes") after the Completion Report.
 
 ## Stage Structure

--- a/references/phase3-merge.md
+++ b/references/phase3-merge.md
@@ -1,9 +1,23 @@
 # Phase 3: Merge (USER-INITIATED)
 
 ```bash
-# Backward-compat guard: if sf-emit.sh wasn't sourced at session start, define a no-op fallback.
-# This ensures sessions without events.jsonl still work (charter non-negotiable).
-command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+# Event emission preloader — idempotent, runs at top of every phase doc bash usage.
+# Tries (in order): already-sourced sf_emit → local tools/sf-emit.sh → runtime-aware paths → no-op.
+# Also restores SUPERFLOW_RUN_ID from state if unset.
+if ! command -v sf_emit >/dev/null 2>&1; then
+  for _sf_path in \
+      "./tools/sf-emit.sh" \
+      "$HOME/.claude/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.codex/skills/superflow/tools/sf-emit.sh" \
+      "$HOME/.agents/skills/superflow/tools/sf-emit.sh"; do
+    if [ -f "$_sf_path" ]; then source "$_sf_path"; break; fi
+  done
+  command -v sf_emit >/dev/null 2>&1 || sf_emit() { return 0; }
+fi
+if [ -z "${SUPERFLOW_RUN_ID:-}" ] && [ -f .superflow-state.json ]; then
+  SUPERFLOW_RUN_ID=$(python3 -c 'import json; print(json.load(open(".superflow-state.json")).get("context",{}).get("run_id",""))' 2>/dev/null)
+  [ -n "$SUPERFLOW_RUN_ID" ] && export SUPERFLOW_RUN_ID
+fi
 ```
 
 Triggered when user says "merge", "мёрдж", "мерж", or gives clear affirmative response (e.g., "go ahead", "do it", "yes") after the Completion Report.

--- a/tools/sf-emit.sh
+++ b/tools/sf-emit.sh
@@ -286,7 +286,7 @@ sf_emit() {
   mkdir -p "$(dirname "$out_file")"
 
   # Append event as a single line
-  printf '%s\n' "$event_json" >> "$out_file"
+  printf '%s\n' "$event_json" >> "$out_file" || return 1
 
   # Rotation check: every _SF_ROTATION_CHECK_INTERVAL calls (default 100)
   _SF_EMIT_CALL_COUNT=$(( _SF_EMIT_CALL_COUNT + 1 ))

--- a/tools/sf-emit.sh
+++ b/tools/sf-emit.sh
@@ -83,8 +83,15 @@ _sf_rotate_log() {
   archive_dir="$(dirname "$out_file")/archive"
   local stamp
   stamp="$(date -u +%Y%m%d-%H%M%S)"
-  # Include PID and call count to guarantee uniqueness within the same second
-  local archive_file="${archive_dir}/events-${stamp}-${$}-${_SF_EMIT_CALL_COUNT}.jsonl"
+  # Base name: timestamp + PID for human readability
+  local archive_base="events-${stamp}-${$}"
+  local archive_file="${archive_dir}/${archive_base}.jsonl"
+  # Collision-proof: if file already exists (same second, same PID), append -N suffix
+  local _n=0
+  while [ -e "$archive_file" ]; do
+    _n=$((_n + 1))
+    archive_file="${archive_dir}/${archive_base}-${_n}.jsonl"
+  done
 
   # Ensure archive directory exists
   mkdir -p "$archive_dir" || {

--- a/tools/sf-emit.sh
+++ b/tools/sf-emit.sh
@@ -1,6 +1,6 @@
 # sf-emit.sh — Superflow event emission library
 # Source-safe: shell options are scoped to sf_emit() only; sourcing this file does not alter caller shell state.
-# Log rotation: see tools/sf-emit.sh Sprint 3 hardening (not yet implemented).
+# Log rotation: threshold-based, triggered every _SF_ROTATION_CHECK_INTERVAL calls inside sf_emit.
 #
 # Usage:
 #   source tools/sf-emit.sh        # once per session
@@ -56,6 +56,89 @@ _SF_KNOWN_TYPES=(
   compact.post
   heartbeat
 )
+
+# ---------------------------------------------------------------------------
+# Log rotation configuration
+# ---------------------------------------------------------------------------
+# Maximum number of lines in events.jsonl before rotation triggers.
+# Default 5000. Set to 0 or negative to disable rotation entirely.
+: "${SUPERFLOW_EVENT_LOG_MAX_LINES:=5000}"
+
+# How often (in sf_emit calls) to check the line count.
+# 1 = check every call (useful for testing); 100 = production default.
+: "${_SF_ROTATION_CHECK_INTERVAL:=100}"
+
+# Per-shell call counter — not exported, not shared across processes.
+_SF_EMIT_CALL_COUNT=0
+
+# _sf_rotate_log <out_file>
+# Rotates out_file to archive/events-<YYYYMMDD-HHMMSS>-<PID>-<N>.jsonl.
+# Uses flock(1) non-blocking advisory lock to prevent concurrent rotation.
+# If flock is unavailable, falls back to a best-effort mv (safe because
+# POSIX append is atomic up to PIPE_BUF; two shells rotating simultaneously
+# is harmless — the later one will see a file below threshold and skip).
+_sf_rotate_log() {
+  local out_file="$1"
+  local archive_dir
+  archive_dir="$(dirname "$out_file")/archive"
+  local stamp
+  stamp="$(date -u +%Y%m%d-%H%M%S)"
+  # Include PID and call count to guarantee uniqueness within the same second
+  local archive_file="${archive_dir}/events-${stamp}-${$}-${_SF_EMIT_CALL_COUNT}.jsonl"
+
+  # Ensure archive directory exists
+  mkdir -p "$archive_dir" || {
+    echo "sf_emit: log rotation failed: cannot create archive dir '$archive_dir'" >&2
+    return 0  # non-fatal
+  }
+
+  # Acquire non-blocking advisory lock to prevent concurrent rotation.
+  # Pattern: redirect fd 9 to lock file, flock -n on it. If flock is not
+  # available or lock is held, skip rotation (another shell is handling it).
+  local lock_file="${out_file}.lock"
+
+  _sf_do_rotate() {
+    mv "$out_file" "$archive_file" || {
+      echo "sf_emit: log rotation failed: mv '$out_file' → '$archive_file'" >&2
+      return 0  # non-fatal; do not block emissions
+    }
+    # out_file is now absent; next sf_emit will re-create it via mkdir+printf
+  }
+
+  # Try flock (Linux, macOS with /usr/bin/flock or Homebrew)
+  if command -v flock &>/dev/null; then
+    (
+      exec 9>"$lock_file"
+      if flock -n 9; then
+        _sf_do_rotate
+      fi
+      # lock released on subshell exit
+    )
+  else
+    # No flock available: best-effort (rotation may race, but append is safe)
+    _sf_do_rotate
+  fi
+}
+
+# _sf_check_rotation <out_file>
+# Called after append. Checks line count and triggers _sf_rotate_log if needed.
+_sf_check_rotation() {
+  local out_file="$1"
+
+  # Rotation disabled when threshold is 0 or negative
+  if [ "${SUPERFLOW_EVENT_LOG_MAX_LINES:-5000}" -le 0 ] 2>/dev/null; then
+    return 0
+  fi
+
+  local line_count
+  line_count="$(wc -l < "$out_file" 2>/dev/null)" || return 0
+
+  if [ "$line_count" -ge "${SUPERFLOW_EVENT_LOG_MAX_LINES}" ]; then
+    _sf_rotate_log "$out_file"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 
 # _sf_uuid — emit a UUID using platform-appropriate method
 _sf_uuid() {
@@ -204,4 +287,65 @@ sf_emit() {
 
   # Append event as a single line
   printf '%s\n' "$event_json" >> "$out_file"
+
+  # Rotation check: every _SF_ROTATION_CHECK_INTERVAL calls (default 100)
+  _SF_EMIT_CALL_COUNT=$(( _SF_EMIT_CALL_COUNT + 1 ))
+  if [ $(( _SF_EMIT_CALL_COUNT % _SF_ROTATION_CHECK_INTERVAL )) -eq 0 ]; then
+    _sf_check_rotation "$out_file"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# _sf_rotation_self_test
+# Manual smoke test for log rotation. Invoke as:
+#   source tools/sf-emit.sh && _sf_rotation_self_test
+# Writes 5500 lines at threshold 5000, checks archive, reports line counts.
+# ---------------------------------------------------------------------------
+_sf_rotation_self_test() {
+  local test_dir
+  test_dir="$(mktemp -d)"
+  echo "sf_rotation_self_test: using temp dir $test_dir"
+
+  local old_events_file="${SUPERFLOW_EVENTS_FILE:-}"
+  local old_run_id="${SUPERFLOW_RUN_ID:-}"
+  local old_max="${SUPERFLOW_EVENT_LOG_MAX_LINES:-5000}"
+  local old_interval="${_SF_ROTATION_CHECK_INTERVAL:-100}"
+
+  export SUPERFLOW_EVENTS_FILE="$test_dir/events.jsonl"
+  export SUPERFLOW_RUN_ID="00000000-0000-4000-8000-000000000099"
+  export SUPERFLOW_EVENT_LOG_MAX_LINES=5000
+  _SF_ROTATION_CHECK_INTERVAL=100
+  _SF_EMIT_CALL_COUNT=0
+
+  echo "sf_rotation_self_test: emitting 5500 heartbeats (threshold=5000, check every 100)..."
+  local i=1
+  while [ $i -le 5500 ]; do
+    sf_emit heartbeat phase2_step=self_test
+    i=$(( i + 1 ))
+  done
+
+  echo ""
+  echo "sf_rotation_self_test: results:"
+  echo "  archive dir contents:"
+  ls -la "$test_dir/archive/" 2>/dev/null || echo "  (archive dir not found)"
+  echo "  line counts:"
+  wc -l "$test_dir/events.jsonl" "$test_dir/archive/"*.jsonl 2>/dev/null || true
+
+  # Restore state
+  if [ -n "$old_events_file" ]; then
+    export SUPERFLOW_EVENTS_FILE="$old_events_file"
+  else
+    unset SUPERFLOW_EVENTS_FILE
+  fi
+  if [ -n "$old_run_id" ]; then
+    export SUPERFLOW_RUN_ID="$old_run_id"
+  else
+    unset SUPERFLOW_RUN_ID
+  fi
+  export SUPERFLOW_EVENT_LOG_MAX_LINES="$old_max"
+  _SF_ROTATION_CHECK_INTERVAL="$old_interval"
+  _SF_EMIT_CALL_COUNT=0
+
+  rm -rf "$test_dir"
+  echo "sf_rotation_self_test: done."
 }

--- a/tools/sf-emit.sh
+++ b/tools/sf-emit.sh
@@ -288,11 +288,9 @@ sf_emit() {
   # Append event as a single line
   printf '%s\n' "$event_json" >> "$out_file" || return 1
 
-  # Rotation check: every _SF_ROTATION_CHECK_INTERVAL calls (default 100)
-  _SF_EMIT_CALL_COUNT=$(( _SF_EMIT_CALL_COUNT + 1 ))
-  if [ $(( _SF_EMIT_CALL_COUNT % _SF_ROTATION_CHECK_INTERVAL )) -eq 0 ]; then
-    _sf_check_rotation "$out_file"
-  fi
+  # Rotation check: runs on every emission. Cost: one wc -l per emission — cheap.
+  # File-state check ensures rotation triggers even in short-lived single-emit invocations.
+  _sf_check_rotation "$out_file"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> Supersedes #75 (auto-closed when base branch `feat/event-log-sprint-2` was deleted after #74 merge).

## Summary

Run 2 Sprint 3 — **hardening** of the event log shipped in Sprint 2.

- **Task 8: log rotation** in `tools/sf-emit.sh` — threshold-based (`SUPERFLOW_EVENT_LOG_MAX_LINES`, default 5000), collision-proof archive names (`events-<ts>-<PID>[-N].jsonl`), concurrency-safe via `flock -n`, self-test function included
- **Task 9: coverage audit** (deep-analyst) produced a 13-item gap report: 4 CRITICAL, 3 HIGH, 6 MEDIUM/LOW
- **Task 10: gap fixes**:
  - `compact.pre`/`compact.post` now emitted by `hooks/precompact-state-externalization.sh` with absolute events-file path
  - `phase.start`/`phase.end` added for Phase 2 entry/exit
  - `heartbeat` events emitted after each state-write
  - `run.end status=blocked` at abandonment points (Phase 0 rejection, Phase 1 abandonment, Phase 2 fix-exhaustion)
  - Phase 0/1 parallel agents instrumented with `agent.dispatch`/`agent.complete` + `agent_id` via `SF_PARENT_ID`
  - Phase 1 spec + plan reviews emit `review.start`/`review.verdict`
  - Rule 13 mirrored into `codex/AGENTS.md`
  - Backward-compat preloader (source-first, then no-op) in 10 phase docs — protects v4.x installs and sessions where sf-emit isn't sourced
  - Write-failure propagation (`|| return 1`) so callers see errors

## Process

- Governance: **standard** · complexity: **medium** · 2 reviewers
- Claude Product Review: **ACCEPTED** round 1 — all 4 charter success criteria confirmed
- Codex Technical Review: **6 rounds**, each surfaced 2-4 P2 edge cases, all fixed in subsequent passes. Final round addressed; technical_review: APPROVE
- Post-review tests: rotation works with threshold=2 (archive created), all 20 schema event types emit valid JSONL, 0 schema violations
- Docs: CLAUDE.md + llms.txt updated (sf-emit line count 207→356, hook entry added); docs_review PASS

## Charter success criteria

- All 20 schema-defined event types have at least one producer
- Log rotation works at >5000 lines (threshold + archive verified)
- Backward compat: sessions without events.jsonl still work (preloader tested)
- Injection safety: sf-emit uses jq `--arg`, no shell interpolation

## Test plan

- [x] Log rotation smoke: 5 emissions at threshold=2 → 2 distinct archives, 1 line in events.jsonl
- [x] 20-event schema sanity: all types emit valid JSONL, 0 violations
- [x] Preloader backward-compat: fresh shell without sf-emit.sh → no-op, no exit 127
- [x] Hook absolute path: `SUPERFLOW_EVENTS_FILE` anchored to `$CWD`
- [x] Rule 13 mirrored in codex/AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)